### PR TITLE
Add Dependabot configuration for uv and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,22 @@
 version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directories:
-      - "/.github/workflows"
+
+multi-ecosystem-groups:
+  all:
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 10
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/workflows"
+    multi-ecosystem-group: "all"
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+    multi-ecosystem-group: "all"
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+    multi-ecosystem-group: "all"


### PR DESCRIPTION
PR #6 added the `.github/dependabot.yml` file with config only for GH Actions updates.

Now this adds configs also for uv and npm controlled dependencies, and groups all updates to a single PR and uses 10 days cooldown for all dependecies.