### PR TITLE
Add drag & drop and copy functionality to web UI

### DIFF
--- a/bibra/static/css/styles.css
+++ b/bibra/static/css/styles.css
@@ -189,6 +189,12 @@ a {
   padding: 0.25rem 0.5rem;
 }
 
+#results .btn-copy:active {
+  background-color: var(--dark-color) !important;
+  color: var(--white-color) !important;
+  transition: none;
+}
+
 #version-info {
   color:var(--muted-color);
 }

--- a/bibra/static/css/styles.css
+++ b/bibra/static/css/styles.css
@@ -81,7 +81,7 @@ a {
   cursor: pointer;
 }
 
-#dropzone:hover {
+#dropzone:hover, #dropzone.dragging {
   background-color: var(--accent-color-50);
   border: 2px dashed var(--accent-color);
 }
@@ -135,7 +135,7 @@ a {
 
 #select-method {
   width: 100%;
-  border: none;
+  border: 1px solid var(--secondary-medium-color);
 }
 
 .btn-submit {

--- a/bibra/static/js/bibra.js
+++ b/bibra/static/js/bibra.js
@@ -12,6 +12,8 @@ const mainApp = Vue.createApp({
       showResults: false,
       loadingResults: false,
       version: '',
+      showDraggingEffect: false,
+      extractPending: false
     }
   },
   mounted () {
@@ -33,7 +35,7 @@ const mainApp = Vue.createApp({
       .then(data => {
         if (data.projects) {
           this.projects = data.projects
-          this.selectedProject = data.projects.length > 0 ? this.projects[0].id : ''
+          this.selectedProject = this.projects[0] && this.projects[0].id
         }
       })
       .catch(err => {
@@ -53,6 +55,44 @@ const mainApp = Vue.createApp({
       this.showPreview = false
       this.showResults = false
       this.loadingResults = false
+    },
+    copy (value) {
+      if (Array.isArray(value)) {
+        navigator.clipboard.writeText(value.join(', '))
+          .catch(err => {
+            console.error(err)
+          })
+      } else {
+        navigator.clipboard.writeText(value)
+          .catch(err => {
+            console.error(err)
+          })
+      }
+    },
+    dragOver(e) {
+      e.stopPropagation()
+      e.preventDefault()
+      this.showDraggingEffect = true
+    },
+    dragLeave(e) {
+      e.stopPropagation()
+      e.preventDefault()
+      this.showDraggingEffect = false
+    },
+    drop (e) {
+      e.stopPropagation()
+      e.preventDefault()
+      this.showDraggingEffect = false
+      
+      const file = e.dataTransfer.files[0]
+      if (file && file.type === 'application/pdf') {
+        this.fileBlob = file
+        this.fileObjectUrl = URL.createObjectURL(this.fileBlob)
+        this.fileName = this.fileBlob.name
+        this.showPreview = true
+      } else {
+        // TODO: show warning about file type
+      }
     },
     handleDropzoneClick (e) {
       e.preventDefault()
@@ -81,14 +121,13 @@ const mainApp = Vue.createApp({
       })
     },
     uploadFile (e) {
-      const file = e.target.files && e.target.files[0]
-      if (file.type === 'application/pdf') {
+      const file = e.target.files[0]
+      if (file && file.type === 'application/pdf') {
         // Store the uploaded file as a blob and assign a blob URL to it
         this.fileBlob = file
         this.fileObjectUrl = URL.createObjectURL(this.fileBlob)
         this.fileName = this.fileBlob.name
         this.showPreview = true
-        this.$refs.file.value = '' // Reset file input so the same file can be uploaded again
       } else {
         // TODO: show a warning about file type in UI
       }
@@ -98,25 +137,32 @@ const mainApp = Vue.createApp({
       this.showResults = false
       this.loadingResults = true
 
-      const formData = new FormData()
-      formData.append('files', this.fileBlob)
+      // Only call extract if a previous call is not pending
+      if (!this.extractPending) {
+        this.extractPending = true
 
-      fetch(`/v0/projects/${this.selectedProject}/extract`, {
-        method: 'POST',
-        body: formData
-      })
-        .then(res => res.json())
-        .then(data => {
-          this.results = data
-          this.loadingResults = false
-          this.showResults = true
+        const formData = new FormData()
+        formData.append('files', this.fileBlob)
+
+        fetch(`/v0/projects/${this.selectedProject}/extract`, {
+          method: 'POST',
+          body: formData
         })
-      .catch(err => {
-        console.error('Failed to extract data from file:', err)
+          .then(res => res.json())
+          .then(data => {
+            this.results = data
+            this.loadingResults = false
+            this.showResults = true
+            this.extractPending = false
+          })
+        .catch(err => {
+          console.error('Failed to extract data from file:', err)
 
-        this.loadingResults = false
-        // TODO: show error message in UI
-      })
+          this.loadingResults = false
+          this.extractPending = false
+          // TODO: show error message in UI
+        })
+      }
     }
   },
   template: `
@@ -136,9 +182,13 @@ const mainApp = Vue.createApp({
 
           <template v-if="!showPreview">
             <div id="dropzone" class="mb-3" role="button" tabindex="0"
+              :class="{ 'dragging': showDraggingEffect }"
               @click="handleDropzoneClick($event)"
               @keydown.space="handleDropzoneClick($event)"
               @keydown.enter="handleDropzoneClick($event)"
+              @drop="drop($event)"
+              @dragover="dragOver($event)"
+              @dragleave="dragLeave($event)"
             >
               <div id="dropzone-background">
                 <i class="fa-solid fa-file-arrow-up" aria-hidden="true"></i>
@@ -163,6 +213,7 @@ const mainApp = Vue.createApp({
                 :data-url="fileObjectUrl"
               ></iframe>
               <button class="btn-clear btn btn-secondary"
+                :aria-label="'Remove ' + fileName"
                 @click="clearInput()"
               >
                 <i class="fa-solid fa-file" aria-hidden="true"></i>
@@ -222,7 +273,7 @@ const mainApp = Vue.createApp({
                       </template>
                     </td>
                     <td class="table-col-copy">
-                      <button class="btn-copy btn btn-secondary">
+                      <button class="btn-copy btn btn-secondary" @click="copy(value)">
                         <i class="fa-regular fa-copy" aria-hidden="true"></i>
                         <span class="visually-hidden">Copy</span>
                       </button>

--- a/bibra/static/js/bibra.js
+++ b/bibra/static/js/bibra.js
@@ -58,7 +58,7 @@ const mainApp = Vue.createApp({
     },
     copy (value) {
       if (Array.isArray(value)) {
-        navigator.clipboard.writeText(value.join(', '))
+        navigator.clipboard.writeText(value.join('\n'))
           .catch(err => {
             console.error(err)
           })

--- a/cypress/e2e/home-page.cy.js
+++ b/cypress/e2e/home-page.cy.js
@@ -41,6 +41,22 @@ describe('Home Page', () => {
     cy.get('.btn-clear').should('have.length', 2)
   })
 
+  it('uploads files with drag and drop', () => {
+    // Drop file on dropzone
+    cy.get('#dropzone').selectFile('cypress/fixtures/test-document.pdf', { action: 'drag-drop' })
+    // Check that preview is visible
+    cy.get('#file-preview').should('be.visible')
+  })
+
+  it('fetches files from URL', () => {
+    // Type in pdf url
+    cy.get('#url-input').type('https://pdfobject.com/pdf/sample.pdf')
+    // Click button to fetch pdf
+    cy.get('#button-select-url').click()
+    // Check that preview is visible
+    cy.get('#file-preview').should('be.visible')
+  })
+
   it('shows results after submit', () => {
     // Check that submit button is disabled
     cy.get('.btn-submit').should('have.class', 'disabled')
@@ -56,6 +72,10 @@ describe('Home Page', () => {
     // Check that results are visible
     cy.get('#results p').should('not.exist')
     cy.get('#results table').should('be.visible')
+    // Check that copy buttons copy correct values
+    cy.get('.btn-copy').eq(0).click()
+    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'en');
+
   })
 
   it('hides preview and results after clear', () => {

--- a/cypress/e2e/home-page.cy.js
+++ b/cypress/e2e/home-page.cy.js
@@ -42,6 +42,8 @@ describe('Home Page', () => {
   })
 
   it('uploads files with drag and drop', () => {
+    // Check that file preview is not visible
+    cy.get('#file-preview').should('not.exist')
     // Drop file on dropzone
     cy.get('#dropzone').selectFile('cypress/fixtures/test-document.pdf', { action: 'drag-drop' })
     // Check that preview is visible
@@ -49,6 +51,8 @@ describe('Home Page', () => {
   })
 
   it('fetches files from URL', () => {
+    // Check that file preview is not visible
+    cy.get('#file-preview').should('not.exist')
     // Type in pdf url
     cy.get('#url-input').type('https://pdfobject.com/pdf/sample.pdf')
     // Click button to fetch pdf


### PR DESCRIPTION
This PR adds drag and drop functionality to dropzone and copying to clipboard to copy buttons.

Changes made:
- Add event handling for drag and drop events for `#dropzone` to upload files and show a dragging effect
- Add a click event for copying values to clipboard for `.btn-copy` elements
- Prevent multiple extract calls from happening simultaneously
- Add correct aria label for `.btn-clear`
- Minor improvements to JS code
- Add cypress tests for drag & drop, copying and fetching from URL