### PR TITLE
Add uv build backend to allow CLI usage via uv run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,3 @@ htmlcov/
 
 # Tests not needed for runtime image
 tests/
-
-# Docs/metadata
-LICENSE
-README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN uv sync --no-dev --no-install-project
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/app/.venv/bin:${PATH}"
 
-# Copy application code.
+# Copy some metadata files and the application code.
+COPY README.md LICENSE ./
 COPY bibra ./bibra
 
 # Install the application package itself (so its version can be determined)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install development dependencies:
 ```bash
 uv sync
 ```
-Install as a CLI tool in editable mode:
+Alternatively, install as a global CLI tool (in editable mode) so prefixing CLI commands with `uv run` is not needed:
 ```bash
 uv tool install -e .
 ```
@@ -41,7 +41,7 @@ Skipping the Ruff checks when committing can be done by adding the `--no-verify`
 ## Usage
 See the available CLI commands:
 ```bash
-bibra
+uv run bibra
 ```
 Start up the server:
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ A metadata extraction and verification tool that integrates multiple methods for
 - **REST API**: Backend microservice for integration with cataloging tools and data enrichment processes
 
 ## Installation
-
+Install development dependencies:
 ```bash
 uv sync
 ```
-
+Install as a CLI tool in editable mode:
+```bash
+uv tool install -e .
+```
+Install web UI dependencies:
 ```bash
 npm install
 ```
@@ -35,7 +39,11 @@ uv run pre-commit install
 Skipping the Ruff checks when committing can be done by adding the `--no-verify` option to the `git commit` command.
 
 ## Usage
-
+See the available CLI commands:
+```bash
+bibra
+```
+Start up the server:
 ```bash
 uv run uvicorn bibra.main:app
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ dev = [
     "schemathesis>=4.18.1",
 ]
 
+[build-system]
+requires = ["uv_build>=0.11.15,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = ""
+
 [tool.ruff]
 line-length = 88
 


### PR DESCRIPTION
I noticed that `pyproject.toml` was missing the [build backend setting](https://docs.astral.sh/uv/concepts/projects/config/#build-systems), which is required for CLI use (see #40) via `uv run bibra <command>` (and maybe also for publishing to PyPI, or would the GH Action work without?).

> A build system determines how the project should be packaged and installed. Projects may declare and configure a build system in the [build-system] table of the pyproject.toml.
>
> uv uses the presence of a build system to determine if a project contains a package that should be installed in the project virtual environment. If a build system is not defined, uv will not attempt to build or install the project itself, just its dependencies. If a build system is defined, uv will build and install the project into the project environment.

Also adds some more details in the usage instructions of README.md, notably how to install as a uv tool (see e.g. [this blog write](https://note.nkmk.me/en/python-uv-cli-tool/)).