### PR TITLE
Configure cool-down period for uv-handled dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
 requires = ["uv_build>=0.11.15,<0.12"]
 build-backend = "uv_build"
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.uv.build-backend]
 module-root = ""
 


### PR DESCRIPTION
uv can be configured to not update any dependency whose artifact has been uploaded in a given period of time: https://docs.astral.sh/uv/reference/settings/#exclude-newer

This PR adds config for this "cool-down" period of one week, which can help in preveventing supply-chain attacks: https://pydevtools.com/handbook/how-to/how-to-protect-against-python-supply-chain-attacks-with-uv/