### PR TITLE
Disable OCR in PyMuPDF4LLM to silence OCR messages on stdout

### DIFF
--- a/bibra/backend/pdf_extractor.py
+++ b/bibra/backend/pdf_extractor.py
@@ -128,6 +128,7 @@ def extract_content(file_path: str) -> dict[str, Any]:
             show_progress=False,
             ignore_images=True,
             ignore_graphics=True,
+            use_ocr=False,
         )
 
     # Score all chunks


### PR DESCRIPTION
Closes #50. We don't really need the PyMuPDF4LLM OCR functionality for the GreyLitLM backend and it will print annoying messages on stdout.

Before:

```
$ uv run bibra extract greylitlm cypress/fixtures/test-document.pdf 
=== Document parser messages ===
Using Tesseract for OCR processing.

{
  "language": "en",
  [...]
}
```

After:

```
$ uv run bibra extract greylitlm cypress/fixtures/test-document.pdf 
{
  "language": "en",
  [...]
}
```