### PR TITLE
Use ruff version set in uv.lock for CI/CD checks to avoid version mismatches

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Ruff lint
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
         with:
           args: "check --diff"
           version-file: "./uv.lock"
 
       - name: Ruff format check
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
         with:
           args: "format --check --diff"
           version-file: "./uv.lock"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,11 +25,13 @@ jobs:
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
         with:
           args: "check --diff"
+          version-file: "./uv.lock"
 
       - name: Ruff format check
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
         with:
           args: "format --check --diff"
+          version-file: "./uv.lock"
 
   pytest:
     name: Unit tests on Python ${{ matrix.python-version }}


### PR DESCRIPTION
[Ruff 0.16 was recently released](https://astral.sh/blog/ruff-v0.16.0) and it includes more checks than the previous version.

We use [astral-sh/ruff-action](https://github.com/astral-sh/ruff-action) in our CI/CD pipeline. By default it auto-detects the ruff version to install from `pyproject.toml`. We have specified the dependency as `"ruff>=0.15.12"` which also allows 0.16.0 and up; however, `uv.lock` sets it at `0.15.12` exactly.

This leads to a mismatch because `ruff-action` will infer that 0.16.0 is fine and install that, even though the code isn't actually 0.16 compliant and `uv` will install 0.15.12. This caused CI/CD ruff checks in my recent PR #60 to fail with many errors, even though the PR itself is a trivial oneliner.

The current version specifier in `pyproject.toml` is a bit questionable (I think it should be restricted to 0.15.* until we fix the codebase to comply with 0.16) but anyway it is problematic that `ruff-action` may use a different version than what is set in `uv.lock`. Thus this PR points `ruff-action` to always use the ruff version set in `uv.lock`. It also upgrades to ruff-action 4.1.0 (from 4.0.0) because only this newest version [supports reading the uv.lock format](https://github.com/astral-sh/ruff-action/pull/379).
