### PR TITLE
update uv.lock after changing ruff version in pyproject.toml

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ruff", specifier = "~=0.16.0" },
     { name = "schemathesis", specifier = ">=4.18.1" },
 ]
 


### PR DESCRIPTION
In #71, I changed pyproject.toml in the last commit but forgot to update uv.lock accordingly. This little PR fixes up uv.lock so it matches the version specifier in pyproject.toml.