### PR TITLE
refactor: Remove dead ExtractRequest code

### DIFF
--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -4,7 +4,6 @@ import tempfile
 from typing import Annotated, Any
 
 from fastapi import APIRouter, File, UploadFile
-from pydantic import BaseModel
 
 from bibra import __version__
 from bibra.backend.dummy import DummyBackend
@@ -14,12 +13,6 @@ from bibra.types import PublicationMetadata
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-class ExtractRequest(BaseModel):
-    """Request model for extract endpoint."""
-
-    files: list[UploadFile]
 
 
 # Example project data - can be extended as needed


### PR DESCRIPTION
Removes the `ExtractRequest` Pydantic model from `bibra/api/v0/routes.py` as it was unused in the current implementation, simplifying the API definition.

This slipped in by mistake in #13, my bad.