### PR TITLE
Improve AGENTS.md + add script for running Cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Dirac AI code editor
+.dirac-cache/
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,4 +47,4 @@ Before considering a task completed, ensure:
 3. ✅ All pytest tests pass (`uv run pytest -v`)
 4. ✅ All Cypress E2E tests pass (`bash cypress/run_cypress.sh`)
 
-**Note: Steps 1–2 must pass before steps 3–4. Ruff should auto-fix issues where possible; manually fix anything it can't.
+**Note: Steps 1–2 must pass before steps 3–4. Ruff should auto-fix issues where possible; manually fix anything it can't.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Running Commands
+
+Do not use `cd` in front of commands, run them from the current directory as is.
+
 ## Python Dependencies
 
 Always use `uv` for dependency management (e.g. `uv add`), **not** `pip` or `uv pip`.
@@ -16,14 +20,14 @@ Python code style follows Ruff format. Max line length 88 chars. Imports on top 
 
 **Ruff checks are a mandatory gate before claiming any task complete.** Every agentic tool invocation must run both:
 
-1. `ruff check --fix` — linting (auto-fix where possible)
-2. `ruff format` — formatting (auto-format)
+1. `uv run ruff check --fix` — linting (auto-fix where possible)
+2. `uv run ruff format` — formatting (auto-format)
 
-Run the checks again with `ruff check` and `ruff format --check` to verify everything passes. Do **not** claim a task complete until both pass.
+Run the checks again with `uv run ruff check` and `uv run ruff format --check` to verify everything passes. Do **not** claim a task complete until both pass.
 
 ## Testing
 
-**Always run Python and Cypress tests after any code changes.**
+**Always run Pytest and Cypress tests after any code changes.**
 
 ### Python Tests
 
@@ -33,14 +37,14 @@ Or run specific test files: `uv run pytest tests/test_<test_file>.py -v`
 
 ### Cypress Tests
 
-Run Cypress E2E tests in headless mode: `npm run cy:run`
+Run Cypress E2E tests in headless mode with the helper script: `bash cypress/run_cypress.sh`
 
 ### Task Completion / Pre-commit Checklist
 
 Before considering a task completed, ensure:
-1. ✅ `ruff check --fix` applied and `ruff check` passes
-2. ✅ `ruff format` applied and `ruff format --check` passes
+1. ✅ `uv run ruff check --fix` applied and `uv run ruff check` passes
+2. ✅ `uv run ruff format` applied and `uv run ruff format --check` passes
 3. ✅ All pytest tests pass (`uv run pytest -v`)
-4. ✅ All Cypress E2E tests pass (`npm run cy:run`)
+4. ✅ All Cypress E2E tests pass (`bash cypress/run_cypress.sh`)
 
 **Note: Steps 1–2 must pass before steps 3–4. Ruff should auto-fix issues where possible; manually fix anything it can't.

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,5 +7,6 @@ module.exports = defineConfig({
     supportFile: 'cypress/support/e2e.js',
     screenshotOnRunFailure: true,
     video: false,
+    allowCypressEnv: false,
   },
 });

--- a/cypress/run_cypress.sh
+++ b/cypress/run_cypress.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 set -e
-echo "Starting uvicorn server..."
-uv run uvicorn bibra.main:app --host 0.0.0.0 --port 8000 2>/dev/null &
+echo "Starting uvicorn server on port 24272 (BIBRA on a phone keypad)..."
+uv run uvicorn bibra.main:app --host 0.0.0.0 --port 24272 2>/dev/null &
 UVICORN_PID=$!
 trap "kill $UVICORN_PID 2>/dev/null" EXIT
+sleep 1
+export CYPRESS_BASE_URL=http://localhost:24272
 npm run cy:run
 

--- a/cypress/run_cypress.sh
+++ b/cypress/run_cypress.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+echo "Starting uvicorn server..."
+uv run uvicorn bibra.main:app --host 0.0.0.0 --port 8000 2>/dev/null &
+UVICORN_PID=$!
+trap "kill $UVICORN_PID 2>/dev/null" EXIT
+exec npm run cy:run
+

--- a/cypress/run_cypress.sh
+++ b/cypress/run_cypress.sh
@@ -5,5 +5,5 @@ echo "Starting uvicorn server..."
 uv run uvicorn bibra.main:app --host 0.0.0.0 --port 8000 2>/dev/null &
 UVICORN_PID=$!
 trap "kill $UVICORN_PID 2>/dev/null" EXIT
-exec npm run cy:run
+npm run cy:run
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,5 +1,2 @@
 // Load Cypress environment variables
 import './commands';
-
-// Global setup for E2E tests
-Cypress.config('baseUrl', 'http://localhost:8000');


### PR DESCRIPTION
## Reasons for creating this PR

When using Zoo Code or Dirac in VSCode, the agents had problems running ruff checks as well as Pytest and Cypress tests. In particular:

1. Zoo tried to run `ruff` commands directly (without `uv run`) and these failed, because the Python venv was not activated.
2. Both agents often used unnecessary `cd` commands before the actual command. This caused extra approval dialogs in some cases, even though the commands themselves were on the auto-approve list.
3. Neither agent could run Cypress tests very well, because the tests depend on a running uvicorn server.
4. Cypress was loudly complaining about the `allowCypressEnv` setting.
5. Dirac cache files tried to sneak into version control.

## Link to relevant issue(s), if any

- n/a

## Description of the changes in this PR

This PR fixes the above problems by

* adding a shell script that starts a temporary Uvicorn process on a hopefully unused port (24272, "BIBRA" on a phone keypad), runs Cypress tests and shuts down Uvicorn at the end
* adjusting Cypress configuration to disable the `allowCypressEnv` setting, which our tests don't need
* adjusting AGENTS.md to better advise agents on how to run commands (without `cd` in front, with `uv run`) and the Cypress test script
* adding Dirac cache files to .gitignore

## Instructions how to test this PR

Use an agent such as Dirac or Zoo. Ask it to "run the checks", "run cypress tests" and similar commands. It should be able to execute the ruff checks as well as Pytest and Cypress tests. If you have added the relevant commands to a list of user-approved commands, there should be no approval dialogs.

## Known problems or uncertainties in this PR

Agents are not fully deterministic so some things may still be off.

AGENTS.md has some repetition that could perhaps be cleaned up.

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

## Disclosure of AI Tool Usage
As AI tools are becoming more and more prevalent, we feel that indicating AI use, how much human effort went into the work and especially into checking the result of AI is good practice. 
There are many ways to do that, we adopted the [AI Traffic Lights Protocol](https://nlkw.de/en/blog/ai-tlp/) by Nila Löber. Please indicate AI use by choosing the most suitable category below and removing the irrelevant categories from the list.

- 🟢 AI:GREEN	AI-assisted. Author drove the process, AI used as a tool (autocomplete, partial generation, refactoring help).

Describe the AI tool you used: I used Qwen3.6-35B-A3B in chat mode to generate the first draft of the run_cypress.sh script, then modified it from there. I used both Dirac and Zoo Code to verify that the fixes worked.

