### PR TITLE
Loading PDF files from URL in REST API and command line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,9 @@ NUEXTRACT_MODEL=nuextract3
 #NUEXTRACT_INSTRUCTIONS=
 #NUEXTRACT_DPI=
 
+# URL Download Proxy (for SSRF mitigation)
+# All URL downloads will be routed through this proxy.
+#BIBRA_URL_PROXY=http://proxy.example.com:8080
+
 # System Settings (optional)
 # LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ NUEXTRACT_MODEL=nuextract3
 #     the CLI falls back to "direct" mode (with full in-app validation).
 #   - "direct": fetch directly (with full in-app validation).
 #   - a URL (e.g. http://proxy.example.com:8080): route through this proxy.
+# The proxy URL itself is operator-trusted (not validated by BIBRA).
+# Ambient HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars are always ignored:
+# only the explicit BIBRA_URL_PROXY can route egress.
 #BIBRA_URL_PROXY=direct
 # Comma-separated list of allowed URL schemes (default: https).
 #BIBRA_URL_SCHEMES=https

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@ NUEXTRACT_MODEL=nuextract3
 
 # URL Fetching (SSRF protection)
 # BIBRA_URL_PROXY controls egress for the extract-url endpoints.
-#   - unset/blank (default): URL fetch/extraction is REFUSED.
+#   - unset/blank (default): the REST API REFUSES URL fetch/extraction;
+#     the CLI falls back to "direct" mode (with full in-app validation).
 #   - "direct": fetch directly (with full in-app validation).
 #   - a URL (e.g. http://proxy.example.com:8080): route through this proxy.
 #BIBRA_URL_PROXY=direct

--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,26 @@ NUEXTRACT_MODEL=nuextract3
 #NUEXTRACT_INSTRUCTIONS=
 #NUEXTRACT_DPI=
 
-# URL Download Proxy (for SSRF mitigation)
-# All URL downloads will be routed through this proxy.
-#BIBRA_URL_PROXY=http://proxy.example.com:8080
+# URL Fetching (SSRF protection)
+# BIBRA_URL_PROXY controls egress for the extract-url endpoints.
+#   - unset/blank (default): URL fetch/extraction is REFUSED.
+#   - "direct": fetch directly (with full in-app validation).
+#   - a URL (e.g. http://proxy.example.com:8080): route through this proxy.
+#BIBRA_URL_PROXY=direct
+# Comma-separated list of allowed URL schemes (default: https).
+#BIBRA_URL_SCHEMES=https
+# Comma-separated list of allowed response content types
+# (default: application/pdf).
+#BIBRA_URL_CONTENT_TYPES=application/pdf
+# Hard cap on download size in bytes (default: 52428800 = 50 MiB).
+#BIBRA_URL_MAX_BYTES=52428800
+# Timeout in seconds for URL downloads (default: 30).
+#BIBRA_URL_TIMEOUT=30
+# Maximum number of redirect hops; every hop is re-validated
+# (default: 5).
+#BIBRA_URL_MAX_REDIRECTS=5
+# Allow URLs whose host is a public IP literal (default: false).
+#BIBRA_URL_ALLOW_IP_HOSTS=false
 
 # System Settings (optional)
 # LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ NUEXTRACT_MODEL=nuextract3
 #BIBRA_URL_CONTENT_TYPES=application/pdf
 # Hard cap on download size in bytes (default: 52428800 = 50 MiB).
 #BIBRA_URL_MAX_BYTES=52428800
-# Timeout in seconds for URL downloads (default: 30).
+# Timeout in seconds for URL downloads (default: 30). Bounds each
+# connect/read/write/pool operation and the total download deadline.
 #BIBRA_URL_TIMEOUT=30
 # Maximum number of redirect hops; every hop is re-validated
 # (default: 5).

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ cypress/cache/
 
 # BIBRA project configuration (copy from projects.toml.example)
 /projects.toml
+plans

--- a/README.md
+++ b/README.md
@@ -84,14 +84,21 @@ hardened fetch layer (`bibra/net_security.py`) that applies defense in depth:
   set to `direct` (fetches directly, still with full in-app validation).
   Set `BIBRA_URL_PROXY` to a proxy URL to route CLI downloads through a
   proxy.
+- **No ambient proxy hijacking.** The fetch layer ignores `HTTP_PROXY`,
+  `HTTPS_PROXY` and `NO_PROXY` environment variables: the only egress route
+  ever in effect is the explicit `BIBRA_URL_PROXY` (if one is configured).
+  Note that the proxy URL itself is operator-trusted and not validated by
+  BIBRA.
 - **Scheme allowlist.** Only `https` by default (extend with
   `BIBRA_URL_SCHEMES`).
-- **Resolved-IP blocking.** The resolved destination IP is checked at connect
-  time (not just the initial URL) against a table of non-public ranges —
-  loopback, RFC 1918, link-local/cloud metadata (`169.254.169.254`), CGNAT,
-  and reserved multicast/unique-local ranges — for both IPv4 and IPv6. This
-  also covers every redirect hop, which defeats DNS-rebinding and
-  redirect-based bypasses.
+- **Resolved-IP blocking (direct mode).** In `direct` mode, the resolved
+  destination IP is checked at connect time (not just the initial URL)
+  against a table of non-public ranges — loopback, RFC 1918, link-local/cloud
+  metadata (`169.254.169.254`), CGNAT, and reserved multicast/unique-local
+  ranges — for both IPv4 and IPv6. This also covers every redirect hop, which
+  defeats DNS-rebinding and redirect-based bypasses. In proxy mode this
+  check is skipped: the proxy's own egress allowlist is the authoritative
+  control, and local DNS results may not match the proxy's resolver.
 - **Resource limits.** A hard byte cap (`BIBRA_URL_MAX_BYTES`) and explicit
   timeouts (`BIBRA_URL_TIMEOUT`) are enforced, and redirects are bounded
   (`BIBRA_URL_MAX_REDIRECTS`).

--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ hardened fetch layer (`bibra/net_security.py`) that applies defense in depth:
   fully eliminate, DNS rebinding; the full protection is provided by
   routing egress through a proxy.
 - **Resource limits.** A hard byte cap (`BIBRA_URL_MAX_BYTES`) and explicit
-  timeouts (`BIBRA_URL_TIMEOUT`) are enforced, and redirects are bounded
-  (`BIBRA_URL_MAX_REDIRECTS`).
+  timeouts (`BIBRA_URL_TIMEOUT`) are enforced — each connect/read/write
+  operation is bounded, and the same value is also the total deadline for
+  the complete download, so a server that drips small chunks to evade the
+  per-read timeout cannot hold a request open indefinitely. Redirects are
+  bounded (`BIBRA_URL_MAX_REDIRECTS`).
 - **Content verification.** The response `Content-Type` must be in
   `BIBRA_URL_CONTENT_TYPES` and the bytes must pass a magic-byte check before
   being handed to a backend.

--- a/README.md
+++ b/README.md
@@ -91,14 +91,21 @@ hardened fetch layer (`bibra/net_security.py`) that applies defense in depth:
   BIBRA.
 - **Scheme allowlist.** Only `https` by default (extend with
   `BIBRA_URL_SCHEMES`).
-- **Resolved-IP blocking (direct mode).** In `direct` mode, the resolved
-  destination IP is checked at connect time (not just the initial URL)
-  against a table of non-public ranges — loopback, RFC 1918, link-local/cloud
-  metadata (`169.254.169.254`), CGNAT, and reserved multicast/unique-local
-  ranges — for both IPv4 and IPv6. This also covers every redirect hop, which
-  defeats DNS-rebinding and redirect-based bypasses. In proxy mode this
-  check is skipped: the proxy's own egress allowlist is the authoritative
-  control, and local DNS results may not match the proxy's resolver.
+- **Resolved-IP blocking (direct mode).** In `direct` mode, the hostname
+  is resolved and every resolved address is checked against a table of
+  non-public ranges — loopback, RFC 1918, link-local/cloud metadata
+  (`169.254.169.254`), CGNAT, and reserved multicast/unique-local ranges —
+  for both IPv4 and IPv6, not just for the initial URL: the check is
+  re-applied on every redirect hop, defeating redirect-based bypasses.
+  In proxy mode this check is skipped: the proxy's own egress allowlist
+  is the authoritative control, and local DNS results may not match the
+  proxy's resolver.
+  *Known limitation:* the check resolves the hostname once and the HTTP
+  transport then resolves it again when dialing the socket, leaving a
+  small TOCTOU window that an actively rebinding DNS resolver could
+  exploit in `direct` mode. The check therefore mitigates, but does not
+  fully eliminate, DNS rebinding; the full protection is provided by
+  routing egress through a proxy.
 - **Resource limits.** A hard byte cap (`BIBRA_URL_MAX_BYTES`) and explicit
   timeouts (`BIBRA_URL_TIMEOUT`) are enforced, and redirects are bounded
   (`BIBRA_URL_MAX_REDIRECTS`).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ Start up the API server and Web UI (add `--reload` for auto-reloading while deve
 
     uv run bibra serve
 
+## Security
+
+The `extract-url` endpoints (API and CLI) fetch a user-supplied URL, which is a
+classic Server-Side Request Forgery (SSRF) vector. BIBRA mitigates this with a
+hardened fetch layer (`bibra/net_security.py`) that applies defense in depth:
+
+- **Egress is off by default.** URL fetch/extraction is refused unless
+  `BIBRA_URL_PROXY` is set. A configured proxy is the recommended production
+  setup (a forward proxy with egress allowlists is the strongest single
+  control); the special value `direct` opts into direct egress with full
+  in-app validation instead.
+- **Scheme allowlist.** Only `https` by default (extend with
+  `BIBRA_URL_SCHEMES`).
+- **Resolved-IP blocking.** The resolved destination IP is checked at connect
+  time (not just the initial URL) against a table of non-public ranges —
+  loopback, RFC 1918, link-local/cloud metadata (`169.254.169.254`), CGNAT,
+  and reserved multicast/unique-local ranges — for both IPv4 and IPv6. This
+  also covers every redirect hop, which defeats DNS-rebinding and
+  redirect-based bypasses.
+- **Resource limits.** A hard byte cap (`BIBRA_URL_MAX_BYTES`) and explicit
+  timeouts (`BIBRA_URL_TIMEOUT`) are enforced, and redirects are bounded
+  (`BIBRA_URL_MAX_REDIRECTS`).
+- **Content verification.** The response `Content-Type` must be in
+  `BIBRA_URL_CONTENT_TYPES` and the bytes must pass a magic-byte check before
+  being handed to a backend.
+
+These options (all `BIBRA_URL_*`) are documented in [.env.example](.env.example).
+
 ## Testing
 
 ### Python Tests

--- a/README.md
+++ b/README.md
@@ -74,11 +74,16 @@ The `extract-url` endpoints (API and CLI) fetch a user-supplied URL, which is a
 classic Server-Side Request Forgery (SSRF) vector. BIBRA mitigates this with a
 hardened fetch layer (`bibra/net_security.py`) that applies defense in depth:
 
-- **Egress is off by default.** URL fetch/extraction is refused unless
-  `BIBRA_URL_PROXY` is set. A configured proxy is the recommended production
-  setup (a forward proxy with egress allowlists is the strongest single
-  control); the special value `direct` opts into direct egress with full
-  in-app validation instead.
+- **Egress is off by default (API).** The REST API refuses URL
+  fetch/extraction unless `BIBRA_URL_PROXY` is set. A configured proxy is the
+  recommended production setup (a forward proxy with egress allowlists is the
+  strongest single control); the special value `direct` opts into direct
+  egress with full in-app validation instead.
+- **CLI fallback.** The CLI is intentionally more lenient for local one-off
+  use: when `BIBRA_URL_PROXY` is unset, `extract-url` behaves as if it were
+  set to `direct` (fetches directly, still with full in-app validation).
+  Set `BIBRA_URL_PROXY` to a proxy URL to route CLI downloads through a
+  proxy.
 - **Scheme allowlist.** Only `https` by default (extend with
   `BIBRA_URL_SCHEMES`).
 - **Resolved-IP blocking.** The resolved destination IP is checked at connect

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -3,9 +3,12 @@
 import logging
 import os
 import tempfile
+import urllib.request
 from typing import Annotated
+from urllib.error import HTTPError, URLError
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from pydantic import HttpUrl
 
 from bibra import __version__
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
@@ -90,6 +93,102 @@ async def extract(
         for tmp_path in temp_files:
             try:
                 os.unlink(tmp_path)
+            except OSError:
+                logger.debug(
+                    "Failed to remove temporary file: %s", tmp_path, exc_info=True
+                )
+
+
+@router.post(
+    "/projects/{project_id}/extract-url",
+    responses={400: {"description": "Bad Request - malformed data"}},
+)
+async def extract_url(
+    project_id: str,
+    registry: Annotated[ProjectRegistry, Depends(get_registry)],
+    urls: list[HttpUrl] = Form(...),
+) -> PublicationMetadata:
+    """
+    Extract publication metadata from PDF or image files at given URLs for a specific project.
+
+    Args:
+        project_id: The ID of the project to extract metadata for
+        urls: List of URLs, each pointing to a file to process
+
+    Returns:
+        PublicationMetadata: Extracted metadata as JSON
+    """
+    temp_files: list[str] = []
+    try:
+        for url in urls:
+            # Create a temporary file to save the downloaded PDF for the current URL
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                temp_files.append(tmp.name)
+
+                try:
+                    # Download content from URL
+                    with urllib.request.urlopen(str(url)) as response:
+                        content_type = response.info().get_content_type()
+                        if content_type != "application/pdf":
+                            if os.path.exists(tmp.name):
+                                os.unlink(tmp.name)
+                                temp_files.remove(tmp.name)
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"'{url}' does not point to a PDF file. Expected 'application/pdf', got '{content_type}'.",
+                            )
+
+                        while chunk := response.read(1024 * 1024):
+                            tmp.write(chunk)
+
+                except HTTPException:
+                    raise
+                except HTTPError as e:
+                    logger.exception(
+                        f"HTTP Error downloading {url}: {e.code} - {e.reason}"
+                    )
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=e.code, detail=str(e))
+                except URLError as e:
+                    logger.exception(f"URL Error downloading {url}: {e.reason}")
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=400, detail=str(e))
+                except Exception as e:
+                    logger.exception(
+                        f"An unexpected error occurred during download from {url}: {e}",
+                        exc_info=True,
+                    )
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=500, detail=str(e))
+
+        # Get backend for the project
+        try:
+            backend = registry.get_backend(project_id)
+        except ProjectNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except ConfigError as e:
+            logger.exception("Configuration error")
+            raise HTTPException(status_code=500, detail=str(e))
+        # Extract metadata using the backend
+        result = await backend.extract(temp_files)
+        return result
+    finally:
+        # Clean up all temporary files that were successfully added to temp_files
+        for tmp_path in temp_files:
+            try:
+                if os.path.exists(
+                    tmp_path
+                ):  # Check if it still exists (might have been removed by an earlier error)
+                    os.unlink(tmp_path)
             except OSError:
                 logger.debug(
                     "Failed to remove temporary file: %s", tmp_path, exc_info=True

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -119,8 +119,17 @@ async def extract_url(
         PublicationMetadata: Extracted metadata as JSON
     """
     try:
-        async with httpx.AsyncClient() as client:
-            url_str = str(url)
+        backend = registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ConfigError as e:
+        logger.exception("Configuration error")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    url_str = str(url)
+
+    try:
+        async with httpx.AsyncClient() as client:  # noqa: SIM117
             async with client.stream("GET", url_str) as response:
                 content_type = response.headers.get("content-type", "")
                 if content_type != "application/pdf":
@@ -138,24 +147,11 @@ async def extract_url(
                         detail=str(response.reason_phrase),
                     )
 
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+                with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
                     async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
                         tmp.write(chunk)
                     tmp.flush()
-
-                    # Get backend for the project
-                    try:
-                        backend = registry.get_backend(project_id)
-                    except ProjectNotFoundError as e:
-                        raise HTTPException(status_code=404, detail=str(e))
-                    except ConfigError as e:
-                        logger.exception("Configuration error")
-                        raise HTTPException(status_code=500, detail=str(e))
-
-                    # Extract metadata using the backend
-                    result = await backend.extract([tmp.name])
-                    return result
-
+                    return await backend.extract([tmp.name])
     except httpx.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -3,10 +3,9 @@
 import logging
 import os
 import tempfile
-import urllib.request
 from typing import Annotated
-from urllib.error import HTTPError, URLError
 
+import httpx
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import HttpUrl
 
@@ -106,10 +105,11 @@ async def extract(
 async def extract_url(
     project_id: str,
     registry: Annotated[ProjectRegistry, Depends(get_registry)],
-    urls: list[HttpUrl] = Form(...),
+    urls: list[HttpUrl] = Form(...),  # noqa: B008
 ) -> PublicationMetadata:
     """
-    Extract publication metadata from PDF or image files at given URLs for a specific project.
+    Extract publication metadata from PDF or image files at given URLs for a
+    specific project.
 
     Args:
         project_id: The ID of the project to extract metadata for
@@ -120,74 +120,76 @@ async def extract_url(
     """
     temp_files: list[str] = []
     try:
-        for url in urls:
-            # Create a temporary file to save the downloaded PDF for the current URL
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                temp_files.append(tmp.name)
+        async with httpx.AsyncClient() as client:
+            for url in urls:
+                # Create a temporary file to save the downloaded PDF for the current URL
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                    temp_files.append(tmp.name)
 
-                try:
-                    # Download content from URL
-                    with urllib.request.urlopen(str(url)) as response:
-                        content_type = response.info().get_content_type()
-                        if content_type != "application/pdf":
-                            if os.path.exists(tmp.name):
-                                os.unlink(tmp.name)
-                                temp_files.remove(tmp.name)
-                            raise HTTPException(
-                                status_code=400,
-                                detail=f"'{url}' does not point to a PDF file. Expected 'application/pdf', got '{content_type}'.",
-                            )
+                    try:
+                        url_str = str(url)
+                        async with client.stream("GET", url_str) as response:
+                            content_type = response.headers.get("content-type", "")
+                            if content_type != "application/pdf":
+                                if os.path.exists(tmp.name):
+                                    os.unlink(tmp.name)
+                                    temp_files.remove(tmp.name)
+                                expected = "application/pdf"
+                                detail = (
+                                    f"'{url}' does not point to a PDF file. "
+                                    f"Expected '{expected}', got '{content_type}'."
+                                )
+                                raise HTTPException(status_code=400, detail=detail)
 
-                        while chunk := response.read(1024 * 1024):
-                            tmp.write(chunk)
+                            status_code = response.status_code
+                            if status_code >= 400:
+                                if os.path.exists(tmp.name):
+                                    os.unlink(tmp.name)
+                                    temp_files.remove(tmp.name)
+                                raise HTTPException(
+                                    status_code=status_code,
+                                    detail=str(response.reason_phrase),
+                                )
 
-                except HTTPException:
-                    raise
-                except HTTPError as e:
-                    logger.exception(
-                        f"HTTP Error downloading {url}: {e.code} - {e.reason}"
-                    )
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=e.code, detail=str(e))
-                except URLError as e:
-                    logger.exception(f"URL Error downloading {url}: {e.reason}")
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=400, detail=str(e))
-                except Exception as e:
-                    logger.exception(
-                        f"An unexpected error occurred during download from {url}: {e}",
-                        exc_info=True,
-                    )
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=500, detail=str(e))
+                            async for chunk in response.aiter_bytes(
+                                chunk_size=1024 * 1024
+                            ):
+                                tmp.write(chunk)
 
-        # Get backend for the project
-        try:
-            backend = registry.get_backend(project_id)
-        except ProjectNotFoundError as e:
-            raise HTTPException(status_code=404, detail=str(e))
-        except ConfigError as e:
-            logger.exception("Configuration error")
-            raise HTTPException(status_code=500, detail=str(e))
-        # Extract metadata using the backend
-        result = await backend.extract(temp_files)
-        return result
+                    except HTTPException:
+                        raise
+                    except httpx.HTTPError as e:
+                        logger.exception("HTTP Error downloading %s", url_str)
+                        if os.path.exists(tmp.name):
+                            os.unlink(tmp.name)
+                            temp_files.remove(tmp.name)
+                        raise HTTPException(status_code=500, detail=str(e))
+                    except Exception as e:
+                        logger.exception(
+                            "Unexpected error during download from %s", url
+                        )
+                        if os.path.exists(tmp.name):
+                            os.unlink(tmp.name)
+                            temp_files.remove(tmp.name)
+                        raise HTTPException(status_code=500, detail=str(e))
+
+            # Get backend for the project
+            try:
+                backend = registry.get_backend(project_id)
+            except ProjectNotFoundError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except ConfigError as e:
+                logger.exception("Configuration error")
+                raise HTTPException(status_code=500, detail=str(e))
+            # Extract metadata using the backend
+            result = await backend.extract(temp_files)
+            return result
     finally:
         # Clean up all temporary files that were successfully added to temp_files
         for tmp_path in temp_files:
             try:
-                if os.path.exists(
-                    tmp_path
-                ):  # Check if it still exists (might have been removed by an earlier error)
+                # Check if it still exists (might have been removed earlier)
+                if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
             except OSError:
                 logger.debug(

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -105,93 +105,60 @@ async def extract(
 async def extract_url(
     project_id: str,
     registry: Annotated[ProjectRegistry, Depends(get_registry)],
-    urls: list[HttpUrl] = Form(...),  # noqa: B008
+    url: HttpUrl = Form(...),  # noqa: B008
 ) -> PublicationMetadata:
     """
-    Extract publication metadata from PDF or image files at given URLs for a
+    Extract publication metadata from a PDF or image file at a given URL for a
     specific project.
 
     Args:
         project_id: The ID of the project to extract metadata for
-        urls: List of URLs, each pointing to a file to process
+        url: URL pointing to a file to process
 
     Returns:
         PublicationMetadata: Extracted metadata as JSON
     """
-    temp_files: list[str] = []
     try:
         async with httpx.AsyncClient() as client:
-            for url in urls:
-                # Create a temporary file to save the downloaded PDF for the current URL
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                    temp_files.append(tmp.name)
+            url_str = str(url)
+            async with client.stream("GET", url_str) as response:
+                content_type = response.headers.get("content-type", "")
+                if content_type != "application/pdf":
+                    expected = "application/pdf"
+                    detail = (
+                        f"'{url}' does not point to a PDF file. "
+                        f"Expected '{expected}', got '{content_type}'."
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
 
+                status_code = response.status_code
+                if status_code >= 400:
+                    raise HTTPException(
+                        status_code=status_code,
+                        detail=str(response.reason_phrase),
+                    )
+
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                        tmp.write(chunk)
+                    tmp.flush()
+
+                    # Get backend for the project
                     try:
-                        url_str = str(url)
-                        async with client.stream("GET", url_str) as response:
-                            content_type = response.headers.get("content-type", "")
-                            if content_type != "application/pdf":
-                                if os.path.exists(tmp.name):
-                                    os.unlink(tmp.name)
-                                    temp_files.remove(tmp.name)
-                                expected = "application/pdf"
-                                detail = (
-                                    f"'{url}' does not point to a PDF file. "
-                                    f"Expected '{expected}', got '{content_type}'."
-                                )
-                                raise HTTPException(status_code=400, detail=detail)
-
-                            status_code = response.status_code
-                            if status_code >= 400:
-                                if os.path.exists(tmp.name):
-                                    os.unlink(tmp.name)
-                                    temp_files.remove(tmp.name)
-                                raise HTTPException(
-                                    status_code=status_code,
-                                    detail=str(response.reason_phrase),
-                                )
-
-                            async for chunk in response.aiter_bytes(
-                                chunk_size=1024 * 1024
-                            ):
-                                tmp.write(chunk)
-
-                    except HTTPException:
-                        raise
-                    except httpx.HTTPError as e:
-                        logger.exception("HTTP Error downloading %s", url_str)
-                        if os.path.exists(tmp.name):
-                            os.unlink(tmp.name)
-                            temp_files.remove(tmp.name)
-                        raise HTTPException(status_code=500, detail=str(e))
-                    except Exception as e:
-                        logger.exception(
-                            "Unexpected error during download from %s", url
-                        )
-                        if os.path.exists(tmp.name):
-                            os.unlink(tmp.name)
-                            temp_files.remove(tmp.name)
+                        backend = registry.get_backend(project_id)
+                    except ProjectNotFoundError as e:
+                        raise HTTPException(status_code=404, detail=str(e))
+                    except ConfigError as e:
+                        logger.exception("Configuration error")
                         raise HTTPException(status_code=500, detail=str(e))
 
-            # Get backend for the project
-            try:
-                backend = registry.get_backend(project_id)
-            except ProjectNotFoundError as e:
-                raise HTTPException(status_code=404, detail=str(e))
-            except ConfigError as e:
-                logger.exception("Configuration error")
-                raise HTTPException(status_code=500, detail=str(e))
-            # Extract metadata using the backend
-            result = await backend.extract(temp_files)
-            return result
-    finally:
-        # Clean up all temporary files that were successfully added to temp_files
-        for tmp_path in temp_files:
-            try:
-                # Check if it still exists (might have been removed earlier)
-                if os.path.exists(tmp_path):
-                    os.unlink(tmp_path)
-            except OSError:
-                logger.debug(
-                    "Failed to remove temporary file: %s", tmp_path, exc_info=True
-                )
+                    # Extract metadata using the backend
+                    result = await backend.extract([tmp.name])
+                    return result
+
+    except httpx.HTTPError as e:
+        logger.exception("HTTP Error downloading %s", url_str)
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        logger.exception("Unexpected error during download from %s", url)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -129,29 +129,30 @@ async def extract_url(
     url_str = str(url)
 
     try:
-        async with httpx.AsyncClient() as client:  # noqa: SIM117
-            async with client.stream("GET", url_str) as response:
-                content_type = response.headers.get("content-type", "")
-                if content_type != "application/pdf":
-                    expected = "application/pdf"
-                    detail = (
-                        f"'{url}' does not point to a PDF file. "
-                        f"Expected '{expected}', got '{content_type}'."
-                    )
-                    raise HTTPException(status_code=400, detail=detail)
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url_str)
 
-                status_code = response.status_code
-                if status_code >= 400:
-                    raise HTTPException(
-                        status_code=status_code,
-                        detail=str(response.reason_phrase),
-                    )
+            content_type = response.headers.get("content-type", "")
+            if content_type != "application/pdf":
+                expected = "application/pdf"
+                detail = (
+                    f"'{url}' does not point to a PDF file. "
+                    f"Expected '{expected}', got '{content_type}'."
+                )
+                raise HTTPException(status_code=400, detail=detail)
 
-                with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
-                        tmp.write(chunk)
-                    tmp.flush()
-                    return await backend.extract([tmp.name])
+            status_code = response.status_code
+            if status_code >= 400:
+                raise HTTPException(
+                    status_code=status_code,
+                    detail=str(response.reason_phrase),
+                )
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+                async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                    tmp.write(chunk)
+                tmp.flush()
+                return await backend.extract([tmp.name])
     except httpx.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -10,7 +10,12 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from pydantic import HttpUrl
 
 from bibra import __version__
-from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.config import (
+    ConfigError,
+    ProjectNotFoundError,
+    ProjectRegistry,
+    get_url_proxy,
+)
 from bibra.types import PublicationMetadata
 
 logger = logging.getLogger(__name__)
@@ -129,7 +134,8 @@ async def extract_url(
     url_str = str(url)
 
     try:
-        async with httpx.AsyncClient() as client:
+        proxy = get_url_proxy()
+        async with httpx.AsyncClient(proxy=proxy) as client:
             response = await client.get(url_str)
 
             content_type = response.headers.get("content-type", "")

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -148,29 +148,41 @@ async def extract_url(
     try:
         proxy = get_url_proxy()
         async with httpx2.AsyncClient(proxy=proxy) as client:
-            response = await client.get(url_str)
+            async with client.stream("GET", url_str) as response:
+                status_code = response.status_code
+                if status_code >= 400:
+                    raise HTTPException(
+                        status_code=status_code,
+                        detail=str(response.reason_phrase),
+                    )
 
-            status_code = response.status_code
-            if status_code >= 400:
-                raise HTTPException(
-                    status_code=status_code,
-                    detail=str(response.reason_phrase),
-                )
+                content_type = response.headers.get("content-type", "")
+                if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
+                    expected = "application/pdf"
+                    detail = (
+                        f"'{url}' does not point to a PDF file. "
+                        f"Expected '{expected}', got '{content_type}'."
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
 
-            content_type = response.headers.get("content-type", "")
-            if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
-                expected = "application/pdf"
-                detail = (
-                    f"'{url}' does not point to a PDF file. "
-                    f"Expected '{expected}', got '{content_type}'."
-                )
-                raise HTTPException(status_code=400, detail=detail)
+                tmp_path: str | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                        tmp_path = tmp.name
+                        async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                            tmp.write(chunk)
 
-            with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-                async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
-                    tmp.write(chunk)
-                tmp.flush()
-                return await backend.extract([tmp.name])
+                    return await backend.extract([tmp_path])
+                finally:
+                    if tmp_path is not None:
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            logger.debug(
+                                "Failed to remove temporary file: %s",
+                                tmp_path,
+                                exc_info=True,
+                            )
     except httpx2.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from typing import Annotated
 
-import httpx
+import httpx2
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import HttpUrl
 
@@ -147,7 +147,7 @@ async def extract_url(
 
     try:
         proxy = get_url_proxy()
-        async with httpx.AsyncClient(proxy=proxy) as client:
+        async with httpx2.AsyncClient(proxy=proxy) as client:
             response = await client.get(url_str)
 
             content_type = response.headers.get("content-type", "")
@@ -171,7 +171,7 @@ async def extract_url(
                     tmp.write(chunk)
                 tmp.flush()
                 return await backend.extract([tmp.name])
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -141,29 +141,30 @@ async def extract_url(
     url_str = str(url)
 
     try:
-        async with httpx.AsyncClient() as client:  # noqa: SIM117
-            async with client.stream("GET", url_str) as response:
-                content_type = response.headers.get("content-type", "")
-                if content_type != "application/pdf":
-                    expected = "application/pdf"
-                    detail = (
-                        f"'{url}' does not point to a PDF file. "
-                        f"Expected '{expected}', got '{content_type}'."
-                    )
-                    raise HTTPException(status_code=400, detail=detail)
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url_str)
 
-                status_code = response.status_code
-                if status_code >= 400:
-                    raise HTTPException(
-                        status_code=status_code,
-                        detail=str(response.reason_phrase),
-                    )
+            content_type = response.headers.get("content-type", "")
+            if content_type != "application/pdf":
+                expected = "application/pdf"
+                detail = (
+                    f"'{url}' does not point to a PDF file. "
+                    f"Expected '{expected}', got '{content_type}'."
+                )
+                raise HTTPException(status_code=400, detail=detail)
 
-                with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
-                        tmp.write(chunk)
-                    tmp.flush()
-                    return await backend.extract([tmp.name])
+            status_code = response.status_code
+            if status_code >= 400:
+                raise HTTPException(
+                    status_code=status_code,
+                    detail=str(response.reason_phrase),
+                )
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+                async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                    tmp.write(chunk)
+                tmp.flush()
+                return await backend.extract([tmp.name])
     except httpx.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -117,93 +117,60 @@ async def extract(
 async def extract_url(
     project_id: str,
     registry: Annotated[ProjectRegistry, Depends(get_registry)],
-    urls: list[HttpUrl] = Form(...),  # noqa: B008
+    url: HttpUrl = Form(...),  # noqa: B008
 ) -> PublicationMetadata:
     """
-    Extract publication metadata from PDF or image files at given URLs for a
+    Extract publication metadata from a PDF or image file at a given URL for a
     specific project.
 
     Args:
         project_id: The ID of the project to extract metadata for
-        urls: List of URLs, each pointing to a file to process
+        url: URL pointing to a file to process
 
     Returns:
         PublicationMetadata: Extracted metadata as JSON
     """
-    temp_files: list[str] = []
     try:
         async with httpx.AsyncClient() as client:
-            for url in urls:
-                # Create a temporary file to save the downloaded PDF for the current URL
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                    temp_files.append(tmp.name)
+            url_str = str(url)
+            async with client.stream("GET", url_str) as response:
+                content_type = response.headers.get("content-type", "")
+                if content_type != "application/pdf":
+                    expected = "application/pdf"
+                    detail = (
+                        f"'{url}' does not point to a PDF file. "
+                        f"Expected '{expected}', got '{content_type}'."
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
 
+                status_code = response.status_code
+                if status_code >= 400:
+                    raise HTTPException(
+                        status_code=status_code,
+                        detail=str(response.reason_phrase),
+                    )
+
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                        tmp.write(chunk)
+                    tmp.flush()
+
+                    # Get backend for the project
                     try:
-                        url_str = str(url)
-                        async with client.stream("GET", url_str) as response:
-                            content_type = response.headers.get("content-type", "")
-                            if content_type != "application/pdf":
-                                if os.path.exists(tmp.name):
-                                    os.unlink(tmp.name)
-                                    temp_files.remove(tmp.name)
-                                expected = "application/pdf"
-                                detail = (
-                                    f"'{url}' does not point to a PDF file. "
-                                    f"Expected '{expected}', got '{content_type}'."
-                                )
-                                raise HTTPException(status_code=400, detail=detail)
-
-                            status_code = response.status_code
-                            if status_code >= 400:
-                                if os.path.exists(tmp.name):
-                                    os.unlink(tmp.name)
-                                    temp_files.remove(tmp.name)
-                                raise HTTPException(
-                                    status_code=status_code,
-                                    detail=str(response.reason_phrase),
-                                )
-
-                            async for chunk in response.aiter_bytes(
-                                chunk_size=1024 * 1024
-                            ):
-                                tmp.write(chunk)
-
-                    except HTTPException:
-                        raise
-                    except httpx.HTTPError as e:
-                        logger.exception("HTTP Error downloading %s", url_str)
-                        if os.path.exists(tmp.name):
-                            os.unlink(tmp.name)
-                            temp_files.remove(tmp.name)
-                        raise HTTPException(status_code=500, detail=str(e))
-                    except Exception as e:
-                        logger.exception(
-                            "Unexpected error during download from %s", url
-                        )
-                        if os.path.exists(tmp.name):
-                            os.unlink(tmp.name)
-                            temp_files.remove(tmp.name)
+                        backend = registry.get_backend(project_id)
+                    except ProjectNotFoundError as e:
+                        raise HTTPException(status_code=404, detail=str(e))
+                    except ConfigError as e:
+                        logger.exception("Configuration error")
                         raise HTTPException(status_code=500, detail=str(e))
 
-            # Get backend for the project
-            try:
-                backend = registry.get_backend(project_id)
-            except ProjectNotFoundError as e:
-                raise HTTPException(status_code=404, detail=str(e))
-            except ConfigError as e:
-                logger.exception("Configuration error")
-                raise HTTPException(status_code=500, detail=str(e))
-            # Extract metadata using the backend
-            result = await backend.extract(temp_files)
-            return result
-    finally:
-        # Clean up all temporary files that were successfully added to temp_files
-        for tmp_path in temp_files:
-            try:
-                # Check if it still exists (might have been removed earlier)
-                if os.path.exists(tmp_path):
-                    os.unlink(tmp_path)
-            except OSError:
-                logger.debug(
-                    "Failed to remove temporary file: %s", tmp_path, exc_info=True
-                )
+                    # Extract metadata using the backend
+                    result = await backend.extract([tmp.name])
+                    return result
+
+    except httpx.HTTPError as e:
+        logger.exception("HTTP Error downloading %s", url_str)
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        logger.exception("Unexpected error during download from %s", url)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -130,7 +130,7 @@ async def extract_url(
     url: HttpUrl = Form(...),  # noqa: B008
 ) -> PublicationMetadata:
     """
-    Extract publication metadata from a PDF or image file at a given URL for a
+    Extract publication metadata from a PDF file at a given URL for a
     specific project.
 
     The download is performed with the SSRF-hardened fetch layer

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -17,6 +17,7 @@ from bibra.net_security import (
     UrlPolicyError,
     fetch_file,
     load_url_fetch_policy,
+    redact_url,
 )
 from bibra.types import Projects, PublicationMetadata, Version
 
@@ -162,18 +163,19 @@ async def extract_url(
     url_str = str(url)
     policy = load_url_fetch_policy()
 
+    safe_url = redact_url(url_str)
     try:
         data = await fetch_file(url_str, policy)
     except ProxyRequiredError as e:
-        logger.info("URL fetch refused (no proxy configured): %s", url_str)
+        logger.info("URL fetch refused (no proxy configured): %s", safe_url)
         raise HTTPException(status_code=503, detail=e.MESSAGE)
     except UrlPolicyError as e:
         # Client-facing message stays generic; details were logged by
         # the fetch layer.
-        logger.info("URL rejected by fetch policy: %s", url_str)
+        logger.info("URL rejected by fetch policy: %s", safe_url)
         raise HTTPException(status_code=400, detail=str(e))
     except httpx2.HTTPError:
-        logger.exception("HTTP Error downloading %s", url_str)
+        logger.exception("HTTP Error downloading %s", safe_url)
         raise HTTPException(status_code=502, detail="Failed to download URL")
 
     return await backend.extract_from_bytes(data)

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -14,8 +14,9 @@ from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
-    get_url_proxy,
+    load_url_fetch_policy,
 )
+from bibra.net_security import ProxyRequiredError, UrlPolicyError, fetch_file
 from bibra.types import Projects, PublicationMetadata, Version
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,11 @@ async def extract(
 
 @router.post(
     "/projects/{project_id}/extract-url",
-    responses={400: {"description": "Bad Request - malformed data"}},
+    responses={
+        400: {"description": "Bad Request - URL or content violates the fetch policy"},
+        502: {"description": "Bad Gateway - download failed"},
+        503: {"description": "Service Unavailable - URL fetching is not configured"},
+    },
 )
 async def extract_url(
     project_id: str,
@@ -128,12 +133,23 @@ async def extract_url(
     Extract publication metadata from a PDF or image file at a given URL for a
     specific project.
 
+    The download is performed with the SSRF-hardened fetch layer
+    (``bibra.net_security``): egress is only allowed through a configured
+    proxy or in explicit direct mode, the URL and every redirect hop are
+    validated against the fetch policy, and the downloaded bytes are
+    verified before being handed to the backend.
+
     Args:
         project_id: The ID of the project to extract metadata for
         url: URL pointing to a file to process
 
     Returns:
         PublicationMetadata: Extracted metadata as JSON
+
+    Raises:
+        HTTPException: 400 if the URL or content violates the fetch policy,
+            404 if the project is unknown, 502 if the download fails,
+            503 if URL fetching is disabled (no proxy/direct configured).
     """
     try:
         backend = registry.get_backend(project_id)
@@ -144,52 +160,36 @@ async def extract_url(
         raise HTTPException(status_code=500, detail=str(e))
 
     url_str = str(url)
+    policy = load_url_fetch_policy()
 
     try:
-        proxy = get_url_proxy()
-        async with (
-            httpx2.AsyncClient(proxy=proxy) as client,
-            client.stream("GET", url_str) as response,
-        ):
-            status_code = response.status_code
-            if status_code >= 400:
-                raise HTTPException(
-                    status_code=status_code,
-                    detail=f"HTTP {status_code} while downloading {url_str}",
-                )
-
-            content_type = response.headers.get("content-type", "")
-            if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
-                expected = "application/pdf"
-                detail = (
-                    f"'{url}' does not point to a PDF file. "
-                    f"Expected '{expected}', got '{content_type}'."
-                )
-                raise HTTPException(status_code=400, detail=detail)
-
-            tmp_path: str | None = None
-            try:
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                    tmp_path = tmp.name
-                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
-                        tmp.write(chunk)
-
-                return await backend.extract([tmp_path])
-            finally:
-                if tmp_path is not None:
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        logger.debug(
-                            "Failed to remove temporary file: %s",
-                            tmp_path,
-                            exc_info=True,
-                        )
-    except HTTPException:
-        raise
-    except httpx2.HTTPError as e:
+        data = await fetch_file(url_str, policy)
+    except ProxyRequiredError as e:
+        logger.info("URL fetch refused (no proxy configured): %s", url_str)
+        raise HTTPException(status_code=503, detail=e.MESSAGE)
+    except UrlPolicyError as e:
+        # Client-facing message stays generic; details were logged by
+        # the fetch layer.
+        logger.info("URL rejected by fetch policy: %s", url_str)
+        raise HTTPException(status_code=400, detail=str(e))
+    except httpx2.HTTPError:
         logger.exception("HTTP Error downloading %s", url_str)
-        raise HTTPException(status_code=500, detail=str(e))
-    except Exception as e:
-        logger.exception("Unexpected error during download from %s", url_str)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=502, detail="Failed to download URL")
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.write(data)
+
+        return await backend.extract([tmp_path])
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                logger.debug(
+                    "Failed to remove temporary file: %s",
+                    tmp_path,
+                    exc_info=True,
+                )

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -131,8 +131,17 @@ async def extract_url(
         PublicationMetadata: Extracted metadata as JSON
     """
     try:
-        async with httpx.AsyncClient() as client:
-            url_str = str(url)
+        backend = registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ConfigError as e:
+        logger.exception("Configuration error")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    url_str = str(url)
+
+    try:
+        async with httpx.AsyncClient() as client:  # noqa: SIM117
             async with client.stream("GET", url_str) as response:
                 content_type = response.headers.get("content-type", "")
                 if content_type != "application/pdf":
@@ -150,24 +159,11 @@ async def extract_url(
                         detail=str(response.reason_phrase),
                     )
 
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+                with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
                     async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
                         tmp.write(chunk)
                     tmp.flush()
-
-                    # Get backend for the project
-                    try:
-                        backend = registry.get_backend(project_id)
-                    except ProjectNotFoundError as e:
-                        raise HTTPException(status_code=404, detail=str(e))
-                    except ConfigError as e:
-                        logger.exception("Configuration error")
-                        raise HTTPException(status_code=500, detail=str(e))
-
-                    # Extract metadata using the backend
-                    result = await backend.extract([tmp.name])
-                    return result
-
+                    return await backend.extract([tmp.name])
     except httpx.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -147,42 +147,44 @@ async def extract_url(
 
     try:
         proxy = get_url_proxy()
-        async with httpx2.AsyncClient(proxy=proxy) as client:
-            async with client.stream("GET", url_str) as response:
-                status_code = response.status_code
-                if status_code >= 400:
-                    raise HTTPException(
-                        status_code=status_code,
-                        detail=str(response.reason_phrase),
-                    )
+        async with (
+            httpx2.AsyncClient(proxy=proxy) as client,
+            client.stream("GET", url_str) as response,
+        ):
+            status_code = response.status_code
+            if status_code >= 400:
+                raise HTTPException(
+                    status_code=status_code,
+                    detail=str(response.reason_phrase),
+                )
 
-                content_type = response.headers.get("content-type", "")
-                if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
-                    expected = "application/pdf"
-                    detail = (
-                        f"'{url}' does not point to a PDF file. "
-                        f"Expected '{expected}', got '{content_type}'."
-                    )
-                    raise HTTPException(status_code=400, detail=detail)
+            content_type = response.headers.get("content-type", "")
+            if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
+                expected = "application/pdf"
+                detail = (
+                    f"'{url}' does not point to a PDF file. "
+                    f"Expected '{expected}', got '{content_type}'."
+                )
+                raise HTTPException(status_code=400, detail=detail)
 
-                tmp_path: str | None = None
-                try:
-                    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                        tmp_path = tmp.name
-                        async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
-                            tmp.write(chunk)
+            tmp_path: str | None = None
+            try:
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                    tmp_path = tmp.name
+                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                        tmp.write(chunk)
 
-                    return await backend.extract([tmp_path])
-                finally:
-                    if tmp_path is not None:
-                        try:
-                            os.unlink(tmp_path)
-                        except OSError:
-                            logger.debug(
-                                "Failed to remove temporary file: %s",
-                                tmp_path,
-                                exc_info=True,
-                            )
+                return await backend.extract([tmp_path])
+            finally:
+                if tmp_path is not None:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        logger.debug(
+                            "Failed to remove temporary file: %s",
+                            tmp_path,
+                            exc_info=True,
+                        )
     except httpx2.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -155,7 +155,7 @@ async def extract_url(
             if status_code >= 400:
                 raise HTTPException(
                     status_code=status_code,
-                    detail=str(response.reason_phrase),
+                    detail=f"HTTP {status_code} while downloading {url_str}",
                 )
 
             content_type = response.headers.get("content-type", "")
@@ -185,9 +185,11 @@ async def extract_url(
                             tmp_path,
                             exc_info=True,
                         )
+    except HTTPException:
+        raise
     except httpx2.HTTPError as e:
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
-        logger.exception("Unexpected error during download from %s", url)
+        logger.exception("Unexpected error during download from %s", url_str)
         raise HTTPException(status_code=500, detail=str(e))

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -176,20 +176,4 @@ async def extract_url(
         logger.exception("HTTP Error downloading %s", url_str)
         raise HTTPException(status_code=502, detail="Failed to download URL")
 
-    tmp_path: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            tmp_path = tmp.name
-            tmp.write(data)
-
-        return await backend.extract([tmp_path])
-    finally:
-        if tmp_path is not None:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                logger.debug(
-                    "Failed to remove temporary file: %s",
-                    tmp_path,
-                    exc_info=True,
-                )
+    return await backend.extract_from_bytes(data)

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -11,13 +11,13 @@ from pydantic import HttpUrl
 
 from bibra import __version__
 from bibra.backend import BaseBackend
-from bibra.config import (
-    ConfigError,
-    ProjectNotFoundError,
-    ProjectRegistry,
+from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.net_security import (
+    ProxyRequiredError,
+    UrlPolicyError,
+    fetch_file,
     load_url_fetch_policy,
 )
-from bibra.net_security import ProxyRequiredError, UrlPolicyError, fetch_file
 from bibra.types import Projects, PublicationMetadata, Version
 
 logger = logging.getLogger(__name__)

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from pydantic import HttpUrl
 
 from bibra import __version__
+from bibra.backend import BaseBackend
 from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
@@ -36,6 +37,17 @@ def get_registry(request: Request) -> ProjectRegistry:
         registry.load()
         request.app.state.project_registry = registry
     return registry
+
+
+def _resolve_backend(registry: ProjectRegistry, project_id: str) -> "BaseBackend":
+    """Return the backend for a project, mapping config errors to HTTP status."""
+    try:
+        return registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ConfigError as e:
+        logger.exception("Configuration error")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get(
@@ -95,13 +107,7 @@ async def extract(
                     tmp.write(chunk)
 
         # Get backend for the project
-        try:
-            backend = registry.get_backend(project_id)
-        except ProjectNotFoundError as e:
-            raise HTTPException(status_code=404, detail=str(e))
-        except ConfigError as e:
-            logger.exception("Configuration error")
-            raise HTTPException(status_code=500, detail=str(e))
+        backend = _resolve_backend(registry, project_id)
         # Extract metadata using the backend
         result = await backend.extract(temp_files)
         return result
@@ -151,13 +157,7 @@ async def extract_url(
             404 if the project is unknown, 502 if the download fails,
             503 if URL fetching is disabled (no proxy/direct configured).
     """
-    try:
-        backend = registry.get_backend(project_id)
-    except ProjectNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except ConfigError as e:
-        logger.exception("Configuration error")
-        raise HTTPException(status_code=500, detail=str(e))
+    backend = _resolve_backend(registry, project_id)
 
     url_str = str(url)
     policy = load_url_fetch_policy()

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -10,7 +10,12 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from pydantic import HttpUrl
 
 from bibra import __version__
-from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.config import (
+    ConfigError,
+    ProjectNotFoundError,
+    ProjectRegistry,
+    get_url_proxy,
+)
 from bibra.types import Projects, PublicationMetadata, Version
 
 logger = logging.getLogger(__name__)
@@ -141,7 +146,8 @@ async def extract_url(
     url_str = str(url)
 
     try:
-        async with httpx.AsyncClient() as client:
+        proxy = get_url_proxy()
+        async with httpx.AsyncClient(proxy=proxy) as client:
             response = await client.get(url_str)
 
             content_type = response.headers.get("content-type", "")

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -13,7 +13,9 @@ from bibra import __version__
 from bibra.backend import BaseBackend
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
 from bibra.net_security import (
+    DownloadSizeExceededError,
     ProxyRequiredError,
+    UnsupportedContentTypeError,
     UrlPolicyError,
     fetch_file,
     load_url_fetch_policy,
@@ -126,7 +128,14 @@ async def extract(
 @router.post(
     "/projects/{project_id}/extract-url",
     responses={
-        400: {"description": "Bad Request - URL or content violates the fetch policy"},
+        400: {
+            "description": (
+                "Bad Request - URL or content violates the fetch policy. The "
+                "detail message is specific to the rejection (oversized "
+                "download, unsupported file type, or URL rejected) but never "
+                "contains internal details."
+            )
+        },
         502: {"description": "Bad Gateway - download failed"},
         503: {"description": "Service Unavailable - URL fetching is not configured"},
     },
@@ -154,9 +163,11 @@ async def extract_url(
         PublicationMetadata: Extracted metadata as JSON
 
     Raises:
-        HTTPException: 400 if the URL or content violates the fetch policy,
-            404 if the project is unknown, 502 if the download fails,
-            503 if URL fetching is disabled (no proxy/direct configured).
+        HTTPException: 400 if the URL or content violates the fetch policy
+            (detail is specific to the rejection: oversized download,
+            unsupported file type, or generic URL rejection), 404 if the
+            project is unknown, 502 if the download fails, 503 if URL
+            fetching is disabled (no proxy/direct configured).
     """
     backend = _resolve_backend(registry, project_id)
 
@@ -169,6 +180,12 @@ async def extract_url(
     except ProxyRequiredError as e:
         logger.info("URL fetch refused (no proxy configured): %s", safe_url)
         raise HTTPException(status_code=503, detail=e.MESSAGE)
+    except DownloadSizeExceededError as e:
+        logger.info("Download rejected (size exceeded): %s", safe_url)
+        raise HTTPException(status_code=400, detail=e.MESSAGE)
+    except UnsupportedContentTypeError as e:
+        logger.info("Download rejected (unsupported type): %s", safe_url)
+        raise HTTPException(status_code=400, detail=e.MESSAGE)
     except UrlPolicyError as e:
         # Client-facing message stays generic; details were logged by
         # the fetch layer.

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -3,9 +3,12 @@
 import logging
 import os
 import tempfile
+import urllib.request
 from typing import Annotated
+from urllib.error import HTTPError, URLError
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from pydantic import HttpUrl
 
 from bibra import __version__
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
@@ -102,6 +105,102 @@ async def extract(
         for tmp_path in temp_files:
             try:
                 os.unlink(tmp_path)
+            except OSError:
+                logger.debug(
+                    "Failed to remove temporary file: %s", tmp_path, exc_info=True
+                )
+
+
+@router.post(
+    "/projects/{project_id}/extract-url",
+    responses={400: {"description": "Bad Request - malformed data"}},
+)
+async def extract_url(
+    project_id: str,
+    registry: Annotated[ProjectRegistry, Depends(get_registry)],
+    urls: list[HttpUrl] = Form(...),
+) -> PublicationMetadata:
+    """
+    Extract publication metadata from PDF or image files at given URLs for a specific project.
+
+    Args:
+        project_id: The ID of the project to extract metadata for
+        urls: List of URLs, each pointing to a file to process
+
+    Returns:
+        PublicationMetadata: Extracted metadata as JSON
+    """
+    temp_files: list[str] = []
+    try:
+        for url in urls:
+            # Create a temporary file to save the downloaded PDF for the current URL
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                temp_files.append(tmp.name)
+
+                try:
+                    # Download content from URL
+                    with urllib.request.urlopen(str(url)) as response:
+                        content_type = response.info().get_content_type()
+                        if content_type != "application/pdf":
+                            if os.path.exists(tmp.name):
+                                os.unlink(tmp.name)
+                                temp_files.remove(tmp.name)
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"'{url}' does not point to a PDF file. Expected 'application/pdf', got '{content_type}'.",
+                            )
+
+                        while chunk := response.read(1024 * 1024):
+                            tmp.write(chunk)
+
+                except HTTPException:
+                    raise
+                except HTTPError as e:
+                    logger.exception(
+                        f"HTTP Error downloading {url}: {e.code} - {e.reason}"
+                    )
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=e.code, detail=str(e))
+                except URLError as e:
+                    logger.exception(f"URL Error downloading {url}: {e.reason}")
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=400, detail=str(e))
+                except Exception as e:
+                    logger.exception(
+                        f"An unexpected error occurred during download from {url}: {e}",
+                        exc_info=True,
+                    )
+                    # Clean up the temporary file associated with the failed download
+                    if os.path.exists(tmp.name):
+                        os.unlink(tmp.name)
+                        temp_files.remove(tmp.name)
+                    raise HTTPException(status_code=500, detail=str(e))
+
+        # Get backend for the project
+        try:
+            backend = registry.get_backend(project_id)
+        except ProjectNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except ConfigError as e:
+            logger.exception("Configuration error")
+            raise HTTPException(status_code=500, detail=str(e))
+        # Extract metadata using the backend
+        result = await backend.extract(temp_files)
+        return result
+    finally:
+        # Clean up all temporary files that were successfully added to temp_files
+        for tmp_path in temp_files:
+            try:
+                if os.path.exists(
+                    tmp_path
+                ):  # Check if it still exists (might have been removed by an earlier error)
+                    os.unlink(tmp_path)
             except OSError:
                 logger.debug(
                     "Failed to remove temporary file: %s", tmp_path, exc_info=True

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -150,21 +150,21 @@ async def extract_url(
         async with httpx2.AsyncClient(proxy=proxy) as client:
             response = await client.get(url_str)
 
-            content_type = response.headers.get("content-type", "")
-            if content_type != "application/pdf":
-                expected = "application/pdf"
-                detail = (
-                    f"'{url}' does not point to a PDF file. "
-                    f"Expected '{expected}', got '{content_type}'."
-                )
-                raise HTTPException(status_code=400, detail=detail)
-
             status_code = response.status_code
             if status_code >= 400:
                 raise HTTPException(
                     status_code=status_code,
                     detail=str(response.reason_phrase),
                 )
+
+            content_type = response.headers.get("content-type", "")
+            if content_type.split(";", 1)[0].strip().lower() != "application/pdf":
+                expected = "application/pdf"
+                detail = (
+                    f"'{url}' does not point to a PDF file. "
+                    f"Expected '{expected}', got '{content_type}'."
+                )
+                raise HTTPException(status_code=400, detail=detail)
 
             with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
                 async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -3,10 +3,9 @@
 import logging
 import os
 import tempfile
-import urllib.request
 from typing import Annotated
-from urllib.error import HTTPError, URLError
 
+import httpx
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import HttpUrl
 
@@ -118,10 +117,11 @@ async def extract(
 async def extract_url(
     project_id: str,
     registry: Annotated[ProjectRegistry, Depends(get_registry)],
-    urls: list[HttpUrl] = Form(...),
+    urls: list[HttpUrl] = Form(...),  # noqa: B008
 ) -> PublicationMetadata:
     """
-    Extract publication metadata from PDF or image files at given URLs for a specific project.
+    Extract publication metadata from PDF or image files at given URLs for a
+    specific project.
 
     Args:
         project_id: The ID of the project to extract metadata for
@@ -132,74 +132,76 @@ async def extract_url(
     """
     temp_files: list[str] = []
     try:
-        for url in urls:
-            # Create a temporary file to save the downloaded PDF for the current URL
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                temp_files.append(tmp.name)
+        async with httpx.AsyncClient() as client:
+            for url in urls:
+                # Create a temporary file to save the downloaded PDF for the current URL
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                    temp_files.append(tmp.name)
 
-                try:
-                    # Download content from URL
-                    with urllib.request.urlopen(str(url)) as response:
-                        content_type = response.info().get_content_type()
-                        if content_type != "application/pdf":
-                            if os.path.exists(tmp.name):
-                                os.unlink(tmp.name)
-                                temp_files.remove(tmp.name)
-                            raise HTTPException(
-                                status_code=400,
-                                detail=f"'{url}' does not point to a PDF file. Expected 'application/pdf', got '{content_type}'.",
-                            )
+                    try:
+                        url_str = str(url)
+                        async with client.stream("GET", url_str) as response:
+                            content_type = response.headers.get("content-type", "")
+                            if content_type != "application/pdf":
+                                if os.path.exists(tmp.name):
+                                    os.unlink(tmp.name)
+                                    temp_files.remove(tmp.name)
+                                expected = "application/pdf"
+                                detail = (
+                                    f"'{url}' does not point to a PDF file. "
+                                    f"Expected '{expected}', got '{content_type}'."
+                                )
+                                raise HTTPException(status_code=400, detail=detail)
 
-                        while chunk := response.read(1024 * 1024):
-                            tmp.write(chunk)
+                            status_code = response.status_code
+                            if status_code >= 400:
+                                if os.path.exists(tmp.name):
+                                    os.unlink(tmp.name)
+                                    temp_files.remove(tmp.name)
+                                raise HTTPException(
+                                    status_code=status_code,
+                                    detail=str(response.reason_phrase),
+                                )
 
-                except HTTPException:
-                    raise
-                except HTTPError as e:
-                    logger.exception(
-                        f"HTTP Error downloading {url}: {e.code} - {e.reason}"
-                    )
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=e.code, detail=str(e))
-                except URLError as e:
-                    logger.exception(f"URL Error downloading {url}: {e.reason}")
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=400, detail=str(e))
-                except Exception as e:
-                    logger.exception(
-                        f"An unexpected error occurred during download from {url}: {e}",
-                        exc_info=True,
-                    )
-                    # Clean up the temporary file associated with the failed download
-                    if os.path.exists(tmp.name):
-                        os.unlink(tmp.name)
-                        temp_files.remove(tmp.name)
-                    raise HTTPException(status_code=500, detail=str(e))
+                            async for chunk in response.aiter_bytes(
+                                chunk_size=1024 * 1024
+                            ):
+                                tmp.write(chunk)
 
-        # Get backend for the project
-        try:
-            backend = registry.get_backend(project_id)
-        except ProjectNotFoundError as e:
-            raise HTTPException(status_code=404, detail=str(e))
-        except ConfigError as e:
-            logger.exception("Configuration error")
-            raise HTTPException(status_code=500, detail=str(e))
-        # Extract metadata using the backend
-        result = await backend.extract(temp_files)
-        return result
+                    except HTTPException:
+                        raise
+                    except httpx.HTTPError as e:
+                        logger.exception("HTTP Error downloading %s", url_str)
+                        if os.path.exists(tmp.name):
+                            os.unlink(tmp.name)
+                            temp_files.remove(tmp.name)
+                        raise HTTPException(status_code=500, detail=str(e))
+                    except Exception as e:
+                        logger.exception(
+                            "Unexpected error during download from %s", url
+                        )
+                        if os.path.exists(tmp.name):
+                            os.unlink(tmp.name)
+                            temp_files.remove(tmp.name)
+                        raise HTTPException(status_code=500, detail=str(e))
+
+            # Get backend for the project
+            try:
+                backend = registry.get_backend(project_id)
+            except ProjectNotFoundError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except ConfigError as e:
+                logger.exception("Configuration error")
+                raise HTTPException(status_code=500, detail=str(e))
+            # Extract metadata using the backend
+            result = await backend.extract(temp_files)
+            return result
     finally:
         # Clean up all temporary files that were successfully added to temp_files
         for tmp_path in temp_files:
             try:
-                if os.path.exists(
-                    tmp_path
-                ):  # Check if it still exists (might have been removed by an earlier error)
+                # Check if it still exists (might have been removed earlier)
+                if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
             except OSError:
                 logger.debug(

--- a/bibra/backend/base.py
+++ b/bibra/backend/base.py
@@ -1,9 +1,14 @@
 """Abstract base class for all backends."""
 
+import logging
+import os
+import tempfile
 from abc import ABC, abstractmethod
 from typing import Any
 
 from bibra.types import PublicationMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class BaseBackend(ABC):
@@ -24,6 +29,36 @@ class BaseBackend(ABC):
         Returns:
             PublicationMetadata: Extracted metadata.
         """
+
+    async def extract_from_bytes(self, data: bytes) -> PublicationMetadata:
+        """Extract publication metadata from in-memory PDF bytes.
+
+        Writes the bytes to a temporary ``.pdf`` file and calls
+        :meth:`extract` with it. The temporary file is removed afterwards,
+        even if extraction fails.
+
+        Args:
+            data: The PDF file contents.
+
+        Returns:
+            PublicationMetadata: Extracted metadata.
+        """
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp_path = tmp.name
+                tmp.write(data)
+            return await self.extract([tmp_path])
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    logger.debug(
+                        "Failed to remove temporary file: %s",
+                        tmp_path,
+                        exc_info=True,
+                    )
 
     @classmethod
     @abstractmethod

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -1,6 +1,8 @@
 """CLI interface for BIBRA."""
 
 import asyncio
+import tempfile
+import urllib.request
 
 import click
 from dotenv import load_dotenv
@@ -92,6 +94,54 @@ def extract(project_id: str, file_path: str, config: str | None, output: str | N
 
     try:
         result = asyncio.run(backend.extract([file_path]))
+    except Exception as e:
+        raise click.ClickException(f"Extraction failed: {e}") from e
+
+    json_output = result.model_dump_json(indent=2)
+
+    if output:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(json_output + "\n")
+        click.echo(f"Output written to {output}")
+    else:
+        click.echo(json_output)
+
+
+@cli.command("extract-url")
+@click.argument("project_id")
+@click.argument("url")
+@click.option(
+    "--config",
+    "-c",
+    default=None,
+    help="Path to the project configuration file (overrides BIBRA_CONFIG).",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+    default=None,
+    help="Write JSON output to file instead of stdout",
+)
+def extract_url(project_id: str, url: str, config: str | None, output: str | None):
+    """Extract publication metadata from a PDF or image file at a URL."""
+    registry = ProjectRegistry(config)
+
+    try:
+        backend = registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise click.UsageError(str(e)) from None
+    except ConfigError as e:
+        raise click.ClickException(str(e)) from None
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+            with urllib.request.urlopen(url) as response:
+                while chunk := response.read(1024 * 1024):
+                    tmp.write(chunk)
+
+            tmp.flush()
+            result = asyncio.run(backend.extract([tmp.name]))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import tempfile
-import urllib.request
 
 import click
+import httpx
 from dotenv import load_dotenv
 
 from bibra.config import (
@@ -136,11 +136,12 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
 
     try:
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-            with urllib.request.urlopen(url) as response:
-                while chunk := response.read(1024 * 1024):
+            with httpx.stream("GET", url) as response:
+                if response.status_code >= 400:
+                    raise httpx.HTTPError(f"HTTP {response.status_code} for {url}")
+                for chunk in response.iter_bytes(chunk_size=1024 * 1024):
                     tmp.write(chunk)
-
-            tmp.flush()
+                tmp.flush()
             result = asyncio.run(backend.extract([tmp.name]))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -11,6 +11,7 @@ from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
+    get_url_proxy,
 )
 
 
@@ -136,7 +137,8 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
 
     try:
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-            with httpx.stream("GET", url) as response:
+            proxy = get_url_proxy()
+            with httpx.stream("GET", url, proxy=proxy) as response:
                 if response.status_code >= 400:
                     raise httpx.HTTPError(f"HTTP {response.status_code} for {url}")
                 for chunk in response.iter_bytes(chunk_size=1024 * 1024):

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -4,7 +4,7 @@ import asyncio
 import tempfile
 
 import click
-import httpx
+import httpx2
 import uvicorn
 from dotenv import load_dotenv
 
@@ -167,9 +167,9 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     try:
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             proxy = get_url_proxy()
-            with httpx.stream("GET", url, proxy=proxy) as response:
+            with httpx2.stream("GET", url, proxy=proxy) as response:
                 if response.status_code >= 400:
-                    raise httpx.HTTPError(f"HTTP {response.status_code} for {url}")
+                    raise httpx2.HTTPError(f"HTTP {response.status_code} for {url}")
                 for chunk in response.iter_bytes(chunk_size=1024 * 1024):
                     tmp.write(chunk)
                 tmp.flush()

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -165,15 +165,28 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
         raise click.ClickException(str(e)) from None
 
     try:
-        with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-            proxy = get_url_proxy()
-            with httpx2.stream("GET", url, proxy=proxy) as response:
-                if response.status_code >= 400:
-                    raise httpx2.HTTPError(f"HTTP {response.status_code} for {url}")
-                for chunk in response.iter_bytes(chunk_size=1024 * 1024):
-                    tmp.write(chunk)
-                tmp.flush()
-            result = asyncio.run(backend.extract([tmp.name]))
+        import os
+
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp_path = tmp.name
+                proxy = get_url_proxy()
+                with httpx2.stream("GET", url, proxy=proxy) as response:
+                    if response.status_code >= 400:
+                        raise httpx2.HTTPError(
+                            f"HTTP {response.status_code} for {url}"
+                        )
+                    for chunk in response.iter_bytes(chunk_size=1024 * 1024):
+                        tmp.write(chunk)
+
+            result = asyncio.run(backend.extract([tmp_path]))
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -1,14 +1,12 @@
 """CLI interface for BIBRA."""
 
 import asyncio
-import dataclasses
 
 import click
 import uvicorn
 from dotenv import load_dotenv
 
 from bibra.config import (
-    URL_FETCH_DIRECT,
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
@@ -177,9 +175,7 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     except ConfigError as e:
         raise click.ClickException(str(e)) from None
 
-    policy = load_url_fetch_policy()
-    if policy.proxy is None:
-        policy = dataclasses.replace(policy, proxy=URL_FETCH_DIRECT)
+    policy = load_url_fetch_policy(cli_fallback=True)
 
     try:
         data = fetch_file_sync(url, policy)

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -1,6 +1,8 @@
 """CLI interface for BIBRA."""
 
 import asyncio
+import tempfile
+import urllib.request
 
 import click
 import uvicorn
@@ -132,3 +134,51 @@ def serve(host: str, port: int, reload: bool):
     # The app is passed as a string import path so that uvicorn's
     # auto-reloader can import it in a separate worker process.
     uvicorn.run("bibra.main:app", host=host, port=port, reload=reload)
+
+
+@cli.command("extract-url")
+@click.argument("project_id")
+@click.argument("url")
+@click.option(
+    "--config",
+    "-c",
+    default=None,
+    help="Path to the project configuration file (overrides BIBRA_CONFIG).",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+    default=None,
+    help="Write JSON output to file instead of stdout",
+)
+def extract_url(project_id: str, url: str, config: str | None, output: str | None):
+    """Extract publication metadata from a PDF or image file at a URL."""
+    registry = ProjectRegistry(config)
+
+    try:
+        backend = registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise click.UsageError(str(e)) from None
+    except ConfigError as e:
+        raise click.ClickException(str(e)) from None
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+            with urllib.request.urlopen(url) as response:
+                while chunk := response.read(1024 * 1024):
+                    tmp.write(chunk)
+
+            tmp.flush()
+            result = asyncio.run(backend.extract([tmp.name]))
+    except Exception as e:
+        raise click.ClickException(f"Extraction failed: {e}") from e
+
+    json_output = result.model_dump_json(indent=2)
+
+    if output:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(json_output + "\n")
+        click.echo(f"Output written to {output}")
+    else:
+        click.echo(json_output)

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import click
+import httpx2
 import uvicorn
 from dotenv import load_dotenv
 
@@ -180,9 +181,11 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     try:
         data = fetch_file_sync(url, policy)
     except UrlPolicyError as e:
-        raise click.ClickException(f"Extraction failed: {e}") from None
-    except Exception as e:
-        raise click.ClickException(f"Extraction failed: {e}") from e
+        # Policy rejection (blocked destination, bad scheme, size cap, ...).
+        raise click.ClickException(f"Extraction failed (policy): {e}") from None
+    except httpx2.HTTPError as e:
+        # Network/download failure (DNS, connection, timeout, HTTP status).
+        raise click.ClickException(f"Extraction failed (network): {e}") from e
 
     try:
         result = asyncio.run(backend.extract_from_bytes(data))

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -157,7 +157,7 @@ def serve(host: str, port: int, reload: bool):
     help="Write JSON output to file instead of stdout",
 )
 def extract_url(project_id: str, url: str, config: str | None, output: str | None):
-    """Extract publication metadata from a PDF or image file at a URL.
+    """Extract publication metadata from a PDF file at a URL."""
 
     The download is performed with the SSRF-hardened fetch layer
     (``bibra.net_security``): the URL and every redirect hop are validated

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -157,7 +157,7 @@ def serve(host: str, port: int, reload: bool):
     help="Write JSON output to file instead of stdout",
 )
 def extract_url(project_id: str, url: str, config: str | None, output: str | None):
-    """Extract publication metadata from a PDF file at a URL."""
+    """Extract publication metadata from a PDF file at a URL.
 
     The download is performed with the SSRF-hardened fetch layer
     (``bibra.net_security``): the URL and every redirect hop are validated

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -8,13 +8,12 @@ import uvicorn
 from dotenv import load_dotenv
 
 from bibra.backend import BaseBackend
-from bibra.config import (
-    ConfigError,
-    ProjectNotFoundError,
-    ProjectRegistry,
+from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.net_security import (
+    UrlPolicyError,
+    fetch_file_sync,
     load_url_fetch_policy,
 )
-from bibra.net_security import UrlPolicyError, fetch_file_sync
 from bibra.types import PublicationMetadata
 
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -2,8 +2,6 @@
 
 import asyncio
 import dataclasses
-import os
-import tempfile
 
 import click
 import uvicorn
@@ -190,24 +188,10 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 
-    tmp_path: str | None = None
     try:
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            tmp_path = tmp.name
-            tmp.write(data)
-
-        result = asyncio.run(backend.extract([tmp_path]))
+        result = asyncio.run(backend.extract_from_bytes(data))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
-    finally:
-        if tmp_path is not None:
-            try:
-                os.unlink(tmp_path)
-            except OSError as e:
-                click.echo(
-                    f"Warning: could not remove temporary file {tmp_path}: {e}",
-                    err=True,
-                )
 
     json_output = result.model_dump_json(indent=2)
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -12,6 +12,7 @@ from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
+    get_url_proxy,
 )
 
 
@@ -165,7 +166,8 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
 
     try:
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-            with httpx.stream("GET", url) as response:
+            proxy = get_url_proxy()
+            with httpx.stream("GET", url, proxy=proxy) as response:
                 if response.status_code >= 400:
                     raise httpx.HTTPError(f"HTTP {response.status_code} for {url}")
                 for chunk in response.iter_bytes(chunk_size=1024 * 1024):

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -183,8 +183,11 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
             if tmp_path is not None:
                 try:
                     os.unlink(tmp_path)
-                except OSError:
-                    pass
+                except OSError as e:
+                    click.echo(
+                        f"Warning: could not remove temporary file {tmp_path}: {e}",
+                        err=True,
+                    )
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -1,6 +1,7 @@
 """CLI interface for BIBRA."""
 
 import asyncio
+import dataclasses
 import os
 import tempfile
 
@@ -9,16 +10,13 @@ import uvicorn
 from dotenv import load_dotenv
 
 from bibra.config import (
+    URL_FETCH_DIRECT,
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
     load_url_fetch_policy,
 )
-from bibra.net_security import (
-    ProxyRequiredError,
-    UrlPolicyError,
-    fetch_file_sync,
-)
+from bibra.net_security import UrlPolicyError, fetch_file_sync
 
 
 def _make_list_template(column_headings: tuple, *rows: tuple) -> str:
@@ -162,10 +160,15 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     """Extract publication metadata from a PDF or image file at a URL.
 
     The download is performed with the SSRF-hardened fetch layer
-    (``bibra.net_security``): egress is only allowed through a configured
-    proxy or in explicit direct mode (see BIBRA_URL_PROXY), the URL and
-    every redirect hop are validated against the fetch policy, and the
-    downloaded bytes are verified before being handed to the backend.
+    (``bibra.net_security``): the URL and every redirect hop are validated
+    against the fetch policy, and the downloaded bytes are verified before
+    being handed to the backend.
+
+    Unlike the REST API, the CLI is more lenient about egress: when
+    BIBRA_URL_PROXY is not set it behaves as if it were set to "direct",
+    i.e. it fetches directly (with full in-app validation) instead of
+    refusing. Set BIBRA_URL_PROXY to a proxy URL to route CLI downloads
+    through a proxy.
     """
     registry = ProjectRegistry(config)
 
@@ -177,11 +180,11 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
         raise click.ClickException(str(e)) from None
 
     policy = load_url_fetch_policy()
+    if policy.proxy is None:
+        policy = dataclasses.replace(policy, proxy=URL_FETCH_DIRECT)
 
     try:
         data = fetch_file_sync(url, policy)
-    except ProxyRequiredError as e:
-        raise click.ClickException(e.MESSAGE) from None
     except UrlPolicyError as e:
         raise click.ClickException(f"Extraction failed: {e}") from None
     except Exception as e:

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -1,10 +1,10 @@
 """CLI interface for BIBRA."""
 
 import asyncio
+import os
 import tempfile
 
 import click
-import httpx2
 import uvicorn
 from dotenv import load_dotenv
 
@@ -12,7 +12,12 @@ from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
     ProjectRegistry,
-    get_url_proxy,
+    load_url_fetch_policy,
+)
+from bibra.net_security import (
+    ProxyRequiredError,
+    UrlPolicyError,
+    fetch_file_sync,
 )
 
 
@@ -154,7 +159,14 @@ def serve(host: str, port: int, reload: bool):
     help="Write JSON output to file instead of stdout",
 )
 def extract_url(project_id: str, url: str, config: str | None, output: str | None):
-    """Extract publication metadata from a PDF or image file at a URL."""
+    """Extract publication metadata from a PDF or image file at a URL.
+
+    The download is performed with the SSRF-hardened fetch layer
+    (``bibra.net_security``): egress is only allowed through a configured
+    proxy or in explicit direct mode (see BIBRA_URL_PROXY), the URL and
+    every redirect hop are validated against the fetch policy, and the
+    downloaded bytes are verified before being handed to the backend.
+    """
     registry = ProjectRegistry(config)
 
     try:
@@ -164,32 +176,35 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     except ConfigError as e:
         raise click.ClickException(str(e)) from None
 
+    policy = load_url_fetch_policy()
+
     try:
-        import os
-
-        tmp_path: str | None = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                tmp_path = tmp.name
-                proxy = get_url_proxy()
-                with httpx2.stream("GET", url, proxy=proxy) as response:
-                    if response.status_code >= 400:
-                        raise httpx2.HTTPError(f"HTTP {response.status_code} for {url}")
-                    for chunk in response.iter_bytes(chunk_size=1024 * 1024):
-                        tmp.write(chunk)
-
-            result = asyncio.run(backend.extract([tmp_path]))
-        finally:
-            if tmp_path is not None:
-                try:
-                    os.unlink(tmp_path)
-                except OSError as e:
-                    click.echo(
-                        f"Warning: could not remove temporary file {tmp_path}: {e}",
-                        err=True,
-                    )
+        data = fetch_file_sync(url, policy)
+    except ProxyRequiredError as e:
+        raise click.ClickException(e.MESSAGE) from None
+    except UrlPolicyError as e:
+        raise click.ClickException(f"Extraction failed: {e}") from None
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.write(data)
+
+        result = asyncio.run(backend.extract([tmp_path]))
+    except Exception as e:
+        raise click.ClickException(f"Extraction failed: {e}") from e
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                click.echo(
+                    f"Warning: could not remove temporary file {tmp_path}: {e}",
+                    err=True,
+                )
 
     json_output = result.model_dump_json(indent=2)
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -174,9 +174,7 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
                 proxy = get_url_proxy()
                 with httpx2.stream("GET", url, proxy=proxy) as response:
                     if response.status_code >= 400:
-                        raise httpx2.HTTPError(
-                            f"HTTP {response.status_code} for {url}"
-                        )
+                        raise httpx2.HTTPError(f"HTTP {response.status_code} for {url}")
                     for chunk in response.iter_bytes(chunk_size=1024 * 1024):
                         tmp.write(chunk)
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -9,11 +9,7 @@ from dotenv import load_dotenv
 
 from bibra.backend import BaseBackend
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
-from bibra.net_security import (
-    UrlPolicyError,
-    fetch_file_sync,
-    load_url_fetch_policy,
-)
+from bibra.net_security import UrlPolicyError, fetch_file, load_url_fetch_policy
 from bibra.types import PublicationMetadata
 
 
@@ -180,17 +176,18 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
 
     policy = load_url_fetch_policy(cli_fallback=True)
 
+    async def _run() -> PublicationMetadata:
+        data = await fetch_file(url, policy)
+        return await backend.extract_from_bytes(data)
+
     try:
-        data = fetch_file_sync(url, policy)
+        result = asyncio.run(_run())
     except UrlPolicyError as e:
         # Policy rejection (blocked destination, bad scheme, size cap, ...).
         raise click.ClickException(f"Extraction failed (policy): {e}") from None
     except httpx2.HTTPError as e:
         # Network/download failure (DNS, connection, timeout, HTTP status).
         raise click.ClickException(f"Extraction failed (network): {e}") from e
-
-    try:
-        result = asyncio.run(backend.extract_from_bytes(data))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import tempfile
-import urllib.request
 
 import click
+import httpx
 import uvicorn
 from dotenv import load_dotenv
 
@@ -165,11 +165,12 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
 
     try:
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
-            with urllib.request.urlopen(url) as response:
-                while chunk := response.read(1024 * 1024):
+            with httpx.stream("GET", url) as response:
+                if response.status_code >= 400:
+                    raise httpx.HTTPError(f"HTTP {response.status_code} for {url}")
+                for chunk in response.iter_bytes(chunk_size=1024 * 1024):
                     tmp.write(chunk)
-
-            tmp.flush()
+                tmp.flush()
             result = asyncio.run(backend.extract([tmp.name]))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -7,6 +7,7 @@ import httpx2
 import uvicorn
 from dotenv import load_dotenv
 
+from bibra.backend import BaseBackend
 from bibra.config import (
     ConfigError,
     ProjectNotFoundError,
@@ -14,6 +15,7 @@ from bibra.config import (
     load_url_fetch_policy,
 )
 from bibra.net_security import UrlPolicyError, fetch_file_sync
+from bibra.types import PublicationMetadata
 
 
 def _make_list_template(column_headings: tuple, *rows: tuple) -> str:
@@ -65,6 +67,28 @@ def list_projects(config: str | None):
         click.echo(template.format(*row))
 
 
+def _get_backend(project_id: str, config: str | None) -> BaseBackend:
+    """Look up a configured backend, raising Click errors on failure."""
+    registry = ProjectRegistry(config)
+    try:
+        return registry.get_backend(project_id)
+    except ProjectNotFoundError as e:
+        raise click.UsageError(str(e)) from None
+    except ConfigError as e:
+        raise click.ClickException(str(e)) from None
+
+
+def _emit_json(result: PublicationMetadata, output: str | None) -> None:
+    """Write the result as JSON to a file or stdout."""
+    json_output = result.model_dump_json(indent=2)
+    if output:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(json_output + "\n")
+        click.echo(f"Output written to {output}")
+    else:
+        click.echo(json_output)
+
+
 @cli.command("extract")
 @click.argument("project_id")
 @click.argument(
@@ -85,28 +109,14 @@ def list_projects(config: str | None):
 )
 def extract(project_id: str, file_path: str, config: str | None, output: str | None):
     """Extract publication metadata from a PDF or image file."""
-    registry = ProjectRegistry(config)
-
-    try:
-        backend = registry.get_backend(project_id)
-    except ProjectNotFoundError as e:
-        raise click.UsageError(str(e)) from None
-    except ConfigError as e:
-        raise click.ClickException(str(e)) from None
+    backend = _get_backend(project_id, config)
 
     try:
         result = asyncio.run(backend.extract([file_path]))
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 
-    json_output = result.model_dump_json(indent=2)
-
-    if output:
-        with open(output, "w", encoding="utf-8") as f:
-            f.write(json_output + "\n")
-        click.echo(f"Output written to {output}")
-    else:
-        click.echo(json_output)
+    _emit_json(result, output)
 
 
 @cli.command("serve")
@@ -167,14 +177,7 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     refusing. Set BIBRA_URL_PROXY to a proxy URL to route CLI downloads
     through a proxy.
     """
-    registry = ProjectRegistry(config)
-
-    try:
-        backend = registry.get_backend(project_id)
-    except ProjectNotFoundError as e:
-        raise click.UsageError(str(e)) from None
-    except ConfigError as e:
-        raise click.ClickException(str(e)) from None
+    backend = _get_backend(project_id, config)
 
     policy = load_url_fetch_policy(cli_fallback=True)
 
@@ -192,11 +195,4 @@ def extract_url(project_id: str, url: str, config: str | None, output: str | Non
     except Exception as e:
         raise click.ClickException(f"Extraction failed: {e}") from e
 
-    json_output = result.model_dump_json(indent=2)
-
-    if output:
-        with open(output, "w", encoding="utf-8") as f:
-            f.write(json_output + "\n")
-        click.echo(f"Output written to {output}")
-    else:
-        click.echo(json_output)
+    _emit_json(result, output)

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -277,3 +277,12 @@ class ProjectRegistry:
             }
             for project in self._projects.values()
         ]
+
+
+def get_url_proxy() -> str | None:
+    """Return the BIBRA_URL_PROXY environment variable value.
+
+    Returns:
+        The proxy URL string, or None if not set.
+    """
+    return os.environ.get("BIBRA_URL_PROXY")

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -5,7 +5,6 @@ with support for environment variable interpolation.
 """
 
 import importlib
-import logging
 import os
 import tomllib
 from dataclasses import dataclass, field
@@ -15,8 +14,6 @@ from typing import Any
 from pydantic import ValidationError
 
 from bibra.backend import BaseBackend
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
@@ -293,127 +290,3 @@ class ProjectRegistry:
             }
             for project in self._projects.values()
         ]
-
-
-# Sentinel value for BIBRA_URL_PROXY meaning "fetch directly, with the
-# full in-app URL validation". Any other non-blank value is treated as a
-# proxy URL; a blank/unset value means URL fetching is refused entirely.
-URL_FETCH_DIRECT = "direct"
-
-# Defaults for the URL fetch policy (BIBRA_URL_* env vars).
-DEFAULT_URL_SCHEMES: list[str] = ["https"]
-DEFAULT_URL_CONTENT_TYPES: list[str] = ["application/pdf"]
-DEFAULT_URL_MAX_BYTES: int = 50 * 1024 * 1024  # 50 MiB
-DEFAULT_URL_TIMEOUT: int = 30  # seconds
-DEFAULT_URL_MAX_REDIRECTS: int = 5
-DEFAULT_URL_ALLOW_IP_HOSTS: bool = False
-
-
-@dataclass(frozen=True)
-class UrlFetchPolicy:
-    """Policy governing how BIBRA fetches user-supplied URLs (SSRF hardening).
-
-    Attributes:
-        proxy: The egress proxy URL, the literal sentinel "direct" (see
-            URL_FETCH_DIRECT) for direct egress, or None to refuse fetching.
-        schemes: Allowed URL schemes (e.g. ["https"]).
-        content_types: Allowed response content types (MIME, no parameters).
-        max_bytes: Hard cap on total downloaded bytes.
-        timeout: Whole seconds for connect/read/write/pool timeouts.
-        max_redirects: Maximum number of redirect hops; every hop is
-            re-validated against the policy.
-        allow_ip_hosts: Whether URLs whose host is an IP literal are allowed.
-    """
-
-    proxy: str | None
-    schemes: tuple[str, ...]
-    content_types: tuple[str, ...]
-    max_bytes: int
-    timeout: int
-    max_redirects: int
-    allow_ip_hosts: bool
-
-    @property
-    def proxy_required(self) -> bool:
-        """True when URL fetching must be refused (no proxy or direct set)."""
-        return self.proxy is None
-
-
-def _parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
-    """Parse a comma-separated env var into a tuple of stripped strings.
-
-    Falls back to the default when the variable is unset or blank.
-    """
-    raw = os.environ.get(name, "")
-    items = [item.strip().lower() for item in raw.split(",") if item.strip()]
-    return tuple(items) if items else tuple(item.lower() for item in default)
-
-
-def _parse_int_env(name: str, default: int) -> int:
-    """Parse a positive-integer env var, falling back to the default."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.debug("Invalid %s=%r; using default %d", name, raw, default)
-        return default
-    return value if value > 0 else default
-
-
-def _parse_bool_env(name: str, default: bool) -> bool:
-    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
-    raw = os.environ.get(name, "").strip().lower()
-    if not raw:
-        return default
-    return raw in {"1", "true", "yes", "on"}
-
-
-def get_url_proxy() -> str | None:
-    """Return the BIBRA_URL_PROXY environment variable value.
-
-    Blank or whitespace-only values are normalized to None, so that
-    callers can safely pass the result to httpx proxy arguments.
-
-    Returns:
-        The proxy URL string, or None if not set or blank.
-    """
-    proxy = os.environ.get("BIBRA_URL_PROXY")
-    return proxy.strip() if proxy and proxy.strip() else None
-
-
-def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
-    """Build a UrlFetchPolicy from the BIBRA_URL_* environment variables.
-
-    Semantics of BIBRA_URL_PROXY:
-      - unset/blank: URL fetching is refused (proxy_required is True)
-      - "direct": direct egress is allowed, subject to full in-app validation
-      - anything else: used as the egress proxy URL
-
-    With ``cli_fallback=True`` (the CLI's intent), an unset/blank
-    BIBRA_URL_PROXY is treated as "direct" instead of refusing: the CLI
-    is a local tool and falls back to direct egress with full in-app
-    validation, while the REST API keeps refusing by default.
-
-    Invalid numeric/boolean values are logged and replaced by their
-    defaults, so that a misconfigured setting never crashes the app.
-    """
-    proxy = get_url_proxy()
-    if proxy is None and cli_fallback:
-        proxy = URL_FETCH_DIRECT
-    return UrlFetchPolicy(
-        proxy=proxy,
-        schemes=_parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
-        content_types=_parse_list_env(
-            "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES
-        ),
-        max_bytes=_parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
-        timeout=_parse_int_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
-        max_redirects=_parse_int_env(
-            "BIBRA_URL_MAX_REDIRECTS", DEFAULT_URL_MAX_REDIRECTS
-        ),
-        allow_ip_hosts=_parse_bool_env(
-            "BIBRA_URL_ALLOW_IP_HOSTS", DEFAULT_URL_ALLOW_IP_HOSTS
-        ),
-    )

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -332,8 +332,8 @@ def _parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
     Falls back to the default when the variable is unset or blank.
     """
     raw = os.environ.get(name, "")
-    items = [item.strip() for item in raw.split(",") if item.strip()]
-    return tuple(items) if items else tuple(default)
+    items = [item.strip().lower() for item in raw.split(",") if item.strip()]
+    return tuple(items) if items else tuple(item.lower() for item in default)
 
 
 def _parse_int_env(name: str, default: int) -> int:

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -4,8 +4,8 @@ This module provides project configuration loading from TOML files,
 with support for environment variable interpolation.
 """
 
-import logging
 import importlib
+import logging
 import os
 import tomllib
 from dataclasses import dataclass, field

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -383,7 +383,7 @@ def get_url_proxy() -> str | None:
     return proxy.strip() if proxy and proxy.strip() else None
 
 
-def load_url_fetch_policy() -> UrlFetchPolicy:
+def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
     """Build a UrlFetchPolicy from the BIBRA_URL_* environment variables.
 
     Semantics of BIBRA_URL_PROXY:
@@ -391,11 +391,19 @@ def load_url_fetch_policy() -> UrlFetchPolicy:
       - "direct": direct egress is allowed, subject to full in-app validation
       - anything else: used as the egress proxy URL
 
+    With ``cli_fallback=True`` (the CLI's intent), an unset/blank
+    BIBRA_URL_PROXY is treated as "direct" instead of refusing: the CLI
+    is a local tool and falls back to direct egress with full in-app
+    validation, while the REST API keeps refusing by default.
+
     Invalid numeric/boolean values are logged and replaced by their
     defaults, so that a misconfigured setting never crashes the app.
     """
+    proxy = get_url_proxy()
+    if proxy is None and cli_fallback:
+        proxy = URL_FETCH_DIRECT
     return UrlFetchPolicy(
-        proxy=get_url_proxy(),
+        proxy=proxy,
         schemes=_parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
         content_types=_parse_list_env(
             "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from bibra.backend import BaseBackend
+from bibra.env import interpolate_dict_values, interpolate_env_vars
 
 
 class ConfigError(Exception):
@@ -96,52 +97,6 @@ class ProjectConfig:
     extra: dict[str, Any] = field(default_factory=dict)
 
 
-def _interpolate_env_vars(value: Any) -> Any:
-    """Interpolate environment variables in a string value.
-
-    Supports ${VAR_NAME} syntax. If the environment variable is not set,
-    the original placeholder is preserved.
-
-    Args:
-        value: The string value to interpolate.
-
-    Returns:
-        The interpolated string, or the input unchanged if non-string.
-    """
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        return value
-
-    result = value
-    start = 0
-    while start < len(result):
-        open_pos = result.find("${", start)
-        if open_pos == -1:
-            break
-        close_pos = result.find("}", open_pos + 2)
-        if close_pos == -1:
-            break
-
-        var_name = result[open_pos + 2 : close_pos]
-        env_value = os.environ.get(var_name)
-        if env_value is not None:
-            result = result[:open_pos] + env_value + result[close_pos + 1 :]
-            start = open_pos + len(env_value)
-        else:
-            start = close_pos + 1
-
-    return result
-
-
-def _interpolate_dict_values(d: dict[str, Any]) -> dict[str, Any]:
-    """Interpolate environment variables in all string values of a dict."""
-    return {
-        key: _interpolate_env_vars(value) if isinstance(value, str) else value
-        for key, value in d.items()
-    }
-
-
 class ProjectRegistry:
     """Loads and manages project configurations from a TOML file.
 
@@ -193,7 +148,7 @@ class ProjectRegistry:
         if isinstance(raw_defaults, dict):
             for key, value in raw_defaults.items():
                 if isinstance(value, str):
-                    defaults[key] = _interpolate_env_vars(value)
+                    defaults[key] = interpolate_env_vars(value)
                 else:
                     defaults[key] = value
 
@@ -207,7 +162,7 @@ class ProjectRegistry:
             merged: dict[str, Any] = dict(defaults)
             merged.update(config)
             # Interpolate all string values in merged
-            merged = _interpolate_dict_values(merged)
+            merged = interpolate_dict_values(merged)
 
             backend_type = merged.get("backend")
             if backend_type is None:

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -304,7 +304,7 @@ URL_FETCH_DIRECT = "direct"
 DEFAULT_URL_SCHEMES: list[str] = ["https"]
 DEFAULT_URL_CONTENT_TYPES: list[str] = ["application/pdf"]
 DEFAULT_URL_MAX_BYTES: int = 50 * 1024 * 1024  # 50 MiB
-DEFAULT_URL_TIMEOUT: float = 30.0  # seconds
+DEFAULT_URL_TIMEOUT: int = 30  # seconds
 DEFAULT_URL_MAX_REDIRECTS: int = 5
 DEFAULT_URL_ALLOW_IP_HOSTS: bool = False
 
@@ -319,7 +319,7 @@ class UrlFetchPolicy:
         schemes: Allowed URL schemes (e.g. ["https"]).
         content_types: Allowed response content types (MIME, no parameters).
         max_bytes: Hard cap on total downloaded bytes.
-        timeout: Seconds for connect/read/write/pool timeouts.
+        timeout: Whole seconds for connect/read/write/pool timeouts.
         max_redirects: Maximum number of redirect hops; every hop is
             re-validated against the policy.
         allow_ip_hosts: Whether URLs whose host is an IP literal are allowed.
@@ -329,7 +329,7 @@ class UrlFetchPolicy:
     schemes: tuple[str, ...]
     content_types: tuple[str, ...]
     max_bytes: int
-    timeout: float
+    timeout: int
     max_redirects: int
     allow_ip_hosts: bool
 
@@ -358,19 +358,6 @@ def _parse_int_env(name: str, default: int) -> int:
         value = int(raw)
     except ValueError:
         logger.debug("Invalid %s=%r; using default %d", name, raw, default)
-        return default
-    return value if value > 0 else default
-
-
-def _parse_float_env(name: str, default: float) -> float:
-    """Parse a positive-float env var, falling back to the default."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        logger.debug("Invalid %s=%r; using default %f", name, raw, default)
         return default
     return value if value > 0 else default
 
@@ -422,7 +409,7 @@ def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
             "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES
         ),
         max_bytes=_parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
-        timeout=_parse_float_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
+        timeout=_parse_int_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
         max_redirects=_parse_int_env(
             "BIBRA_URL_MAX_REDIRECTS", DEFAULT_URL_MAX_REDIRECTS
         ),

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -282,7 +282,11 @@ class ProjectRegistry:
 def get_url_proxy() -> str | None:
     """Return the BIBRA_URL_PROXY environment variable value.
 
+    Blank or whitespace-only values are normalized to None, so that
+    callers can safely pass the result to httpx proxy arguments.
+
     Returns:
-        The proxy URL string, or None if not set.
+        The proxy URL string, or None if not set or blank.
     """
-    return os.environ.get("BIBRA_URL_PROXY")
+    proxy = os.environ.get("BIBRA_URL_PROXY")
+    return proxy.strip() if proxy and proxy.strip() else None

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -4,6 +4,7 @@ This module provides project configuration loading from TOML files,
 with support for environment variable interpolation.
 """
 
+import logging
 import os
 import tomllib
 from dataclasses import dataclass, field
@@ -16,6 +17,8 @@ from bibra.backend.base import BaseBackend
 from bibra.backend.dummy import DummyBackend
 from bibra.backend.greylitlm import GreyLitLMBackend
 from bibra.backend.nuextract import NuExtractBackend
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
@@ -279,6 +282,94 @@ class ProjectRegistry:
         ]
 
 
+# Sentinel value for BIBRA_URL_PROXY meaning "fetch directly, with the
+# full in-app URL validation". Any other non-blank value is treated as a
+# proxy URL; a blank/unset value means URL fetching is refused entirely.
+URL_FETCH_DIRECT = "direct"
+
+# Defaults for the URL fetch policy (BIBRA_URL_* env vars).
+DEFAULT_URL_SCHEMES: list[str] = ["https"]
+DEFAULT_URL_CONTENT_TYPES: list[str] = ["application/pdf"]
+DEFAULT_URL_MAX_BYTES: int = 50 * 1024 * 1024  # 50 MiB
+DEFAULT_URL_TIMEOUT: float = 30.0  # seconds
+DEFAULT_URL_MAX_REDIRECTS: int = 5
+DEFAULT_URL_ALLOW_IP_HOSTS: bool = False
+
+
+@dataclass(frozen=True)
+class UrlFetchPolicy:
+    """Policy governing how BIBRA fetches user-supplied URLs (SSRF hardening).
+
+    Attributes:
+        proxy: The egress proxy URL, the literal sentinel "direct" (see
+            URL_FETCH_DIRECT) for direct egress, or None to refuse fetching.
+        schemes: Allowed URL schemes (e.g. ["https"]).
+        content_types: Allowed response content types (MIME, no parameters).
+        max_bytes: Hard cap on total downloaded bytes.
+        timeout: Seconds for connect/read/write/pool timeouts.
+        max_redirects: Maximum number of redirect hops; every hop is
+            re-validated against the policy.
+        allow_ip_hosts: Whether URLs whose host is an IP literal are allowed.
+    """
+
+    proxy: str | None
+    schemes: tuple[str, ...]
+    content_types: tuple[str, ...]
+    max_bytes: int
+    timeout: float
+    max_redirects: int
+    allow_ip_hosts: bool
+
+    @property
+    def proxy_required(self) -> bool:
+        """True when URL fetching must be refused (no proxy or direct set)."""
+        return self.proxy is None
+
+
+def _parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
+    """Parse a comma-separated env var into a tuple of stripped strings.
+
+    Falls back to the default when the variable is unset or blank.
+    """
+    raw = os.environ.get(name, "")
+    items = [item.strip() for item in raw.split(",") if item.strip()]
+    return tuple(items) if items else tuple(default)
+
+
+def _parse_int_env(name: str, default: int) -> int:
+    """Parse a positive-integer env var, falling back to the default."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.debug("Invalid %s=%r; using default %d", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+def _parse_float_env(name: str, default: float) -> float:
+    """Parse a positive-float env var, falling back to the default."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.debug("Invalid %s=%r; using default %f", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
 def get_url_proxy() -> str | None:
     """Return the BIBRA_URL_PROXY environment variable value.
 
@@ -290,3 +381,31 @@ def get_url_proxy() -> str | None:
     """
     proxy = os.environ.get("BIBRA_URL_PROXY")
     return proxy.strip() if proxy and proxy.strip() else None
+
+
+def load_url_fetch_policy() -> UrlFetchPolicy:
+    """Build a UrlFetchPolicy from the BIBRA_URL_* environment variables.
+
+    Semantics of BIBRA_URL_PROXY:
+      - unset/blank: URL fetching is refused (proxy_required is True)
+      - "direct": direct egress is allowed, subject to full in-app validation
+      - anything else: used as the egress proxy URL
+
+    Invalid numeric/boolean values are logged and replaced by their
+    defaults, so that a misconfigured setting never crashes the app.
+    """
+    return UrlFetchPolicy(
+        proxy=get_url_proxy(),
+        schemes=_parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
+        content_types=_parse_list_env(
+            "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES
+        ),
+        max_bytes=_parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
+        timeout=_parse_float_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
+        max_redirects=_parse_int_env(
+            "BIBRA_URL_MAX_REDIRECTS", DEFAULT_URL_MAX_REDIRECTS
+        ),
+        allow_ip_hosts=_parse_bool_env(
+            "BIBRA_URL_ALLOW_IP_HOSTS", DEFAULT_URL_ALLOW_IP_HOSTS
+        ),
+    )

--- a/bibra/env.py
+++ b/bibra/env.py
@@ -83,8 +83,17 @@ def parse_int_env(name: str, default: int) -> int:
 
 
 def parse_bool_env(name: str, default: bool) -> bool:
-    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
+    """Parse a boolean env var, falling back to the default on malformed values.
+
+    Recognized true values: 1/true/yes/on. Recognized false values:
+    0/false/no/off. Anything else is logged and replaced by the default.
+    """
     raw = os.environ.get(name, "").strip().lower()
     if not raw:
         return default
-    return raw in {"1", "true", "yes", "on"}
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    logger.debug("Invalid %s=%r; using default %s", name, raw, default)
+    return default

--- a/bibra/env.py
+++ b/bibra/env.py
@@ -1,0 +1,90 @@
+"""Generic environment variable helpers.
+
+Utilities for reading and interpreting values from ``os.environ``:
+interpolating ``${VAR_NAME}`` placeholders into strings, and parsing
+comma-separated lists, positive integers, and boolean flags with
+sane fallbacks to defaults on unset or malformed values.
+"""
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def interpolate_env_vars(value: Any) -> Any:
+    """Interpolate environment variables in a string value.
+
+    Supports ${VAR_NAME} syntax. If the environment variable is not set,
+    the original placeholder is preserved.
+
+    Args:
+        value: The string value to interpolate.
+
+    Returns:
+        The interpolated string, or the input unchanged if non-string.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+
+    result = value
+    start = 0
+    while start < len(result):
+        open_pos = result.find("${", start)
+        if open_pos == -1:
+            break
+        close_pos = result.find("}", open_pos + 2)
+        if close_pos == -1:
+            break
+
+        var_name = result[open_pos + 2 : close_pos]
+        env_value = os.environ.get(var_name)
+        if env_value is not None:
+            result = result[:open_pos] + env_value + result[close_pos + 1 :]
+            start = open_pos + len(env_value)
+        else:
+            start = close_pos + 1
+
+    return result
+
+
+def interpolate_dict_values(d: dict[str, Any]) -> dict[str, Any]:
+    """Interpolate environment variables in all string values of a dict."""
+    return {
+        key: interpolate_env_vars(value) if isinstance(value, str) else value
+        for key, value in d.items()
+    }
+
+
+def parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
+    """Parse a comma-separated env var into a tuple of stripped strings.
+
+    Falls back to the default when the variable is unset or blank.
+    """
+    raw = os.environ.get(name, "")
+    items = [item.strip().lower() for item in raw.split(",") if item.strip()]
+    return tuple(items) if items else tuple(item.lower() for item in default)
+
+
+def parse_int_env(name: str, default: int) -> int:
+    """Parse a positive-integer env var, falling back to the default."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.debug("Invalid %s=%r; using default %d", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+def parse_bool_env(name: str, default: bool) -> bool:
+    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -1,10 +1,9 @@
 """Network security helpers for fetching user-supplied URLs.
 
-This module implements the validation layer of BIBRA's SSRF mitigation.
-It contains no network I/O; the fetch function built on top of it lives in
-a later step.
+This module implements BIBRA's SSRF mitigation: a validation layer and a
+hardened fetch function.
 
-Key components:
+Validation components:
     - ``UrlPolicyError``: raised when a URL or downloaded content violates
       the fetch policy. Carries a safe, generic message suitable for
       client-facing error responses; full details are logged server-side.
@@ -15,17 +14,33 @@ Key components:
     - ``ContentValidator`` / ``is_pdf``: pluggable byte-level content
       checks (magic bytes). Currently PDFs are the only supported type;
       future file types add their own validators.
+
+Fetch components:
+    - ``fetch_file`` / ``fetch_file_sync``: download a user-supplied URL
+      with defense in depth: static URL validation, connect-time resolved-IP
+      checking (closes DNS-rebinding and covers every redirect hop), a hard
+      size cap, explicit timeouts, and content-type plus magic-byte
+      verification. Egress is only permitted through a configured proxy or in
+      explicit "direct" mode.
 """
 
+import asyncio
 import ipaddress
 import logging
 import re
+import socket
 import urllib.parse
 from typing import Protocol
 
-from bibra.config import UrlFetchPolicy
+import httpx2
+
+from bibra.config import URL_FETCH_DIRECT, UrlFetchPolicy
 
 logger = logging.getLogger(__name__)
+
+#: Read the response body in chunks no larger than this while enforcing the
+#: size cap, so we can abort mid-stream without buffering unbounded data.
+_FETCH_CHUNK_SIZE = 65536
 
 #: IPv4 ranges that must never be reachable through user-supplied URLs.
 BLOCKED_IPV4_NETS: tuple[ipaddress.IPv4Network, ...] = (
@@ -219,3 +234,224 @@ def is_pdf(data: bytes) -> bool:
     first 1024 bytes of the file.
     """
     return b"%PDF" in data[:1024]
+
+
+class DownloadSizeExceededError(UrlPolicyError):
+    """Raised when a download exceeds the policy's ``max_bytes`` cap."""
+
+    MESSAGE = "Download rejected by fetch policy"
+
+
+class _BlockedDestinationError(Exception):
+    """Internal: a resolved destination IP is blocked by policy.
+
+    Not a ``UrlPolicyError`` on purpose — it is raised inside a transport
+    hook and translated there; callers never see it directly.
+    """
+
+    def __init__(self, url: str, ip: str):
+        super().__init__(f"blocked destination {ip} for {url}")
+        self.url = url
+        self.ip = ip
+
+
+async def _check_destination(host: str, port: int | None) -> None:
+    """Raise _BlockedDestinationError if any resolved IP is blocked.
+
+    Resolves the hostname on the running event loop (non-blocking) and
+    checks every address a connection could hit, which enforces the
+    blocked-IP policy at connect time and mitigates DNS rebinding.
+    IP literals are checked directly without a DNS lookup.
+    """
+    literal = parse_ip_host(host)
+    if literal is not None:
+        if is_blocked_ip(literal):
+            raise _BlockedDestinationError(f"http://{host}", str(literal))
+        return
+
+    if port is None:
+        port = 443
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(
+            host,
+            port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as e:
+        logger.warning("DNS resolution failed for %s: %s", host, e)
+        raise _BlockedDestinationError(f"http://{host}", "unresolvable") from None
+    seen: set[str] = set()
+    for info in infos:
+        ip_str = info[4][0]
+        if ip_str in seen:
+            continue
+        seen.add(ip_str)
+        ip = _normalize_ip(ipaddress.ip_address(ip_str))
+        if is_blocked_ip(ip):
+            raise _BlockedDestinationError(f"http://{host}", str(ip))
+
+
+def _build_async_transport(proxy: str | None) -> httpx2.AsyncHTTPTransport:
+    """Build an async transport that validates each request's destination.
+
+    Every request URL's resolved IP is re-checked at connect time, which
+    closes the DNS-rebinding window and covers every redirect hop
+    (httpx issues a fresh request through the transport for each hop).
+
+    Args:
+        proxy: Proxy URL to route through, or None for direct egress.
+    """
+    proxy_arg = httpx2.Proxy(proxy) if proxy else None
+
+    class _SafeAsyncTransport(httpx2.AsyncHTTPTransport):
+        async def handle_async_request(self, request: httpx2.Request):
+            await _check_destination(request.url.host, request.url.port)
+            return await super().handle_async_request(request)
+
+    return _SafeAsyncTransport(proxy=proxy_arg)
+
+
+def _client_kwargs(policy: UrlFetchPolicy) -> dict:
+    """Build httpx2 AsyncClient kwargs from the policy.
+
+    The ``transport`` kwarg carries the destination-validating transport;
+    no ``proxy`` kwarg is used so that the client does not also mount its
+    own proxy transport (the proxy, when configured, lives inside our
+    transport).
+    """
+    timeout = httpx2.Timeout(policy.timeout)
+    proxy: str | None = None
+    if policy.proxy is not None and policy.proxy != URL_FETCH_DIRECT:
+        proxy = policy.proxy
+
+    return {
+        "timeout": timeout,
+        "follow_redirects": True,
+        "max_redirects": policy.max_redirects,
+        "transport": _build_async_transport(proxy),
+    }
+
+
+def _validate_response_headers(
+    response: httpx2.Response, policy: UrlFetchPolicy
+) -> None:
+    """Check the response Content-Type against the policy allowlist."""
+    raw = response.headers.get("content-type", "")
+    media_type = raw.split(";", 1)[0].strip().lower()
+    if media_type not in policy.content_types:
+        logger.warning(
+            "Content-Type %r rejected (allowed: %s)",
+            media_type,
+            ",".join(policy.content_types),
+        )
+        raise UrlPolicyError("URL rejected by fetch policy")
+
+
+def _validate_content(
+    data: bytes, expected_types: tuple[ContentValidator, ...]
+) -> None:
+    """Verify the downloaded bytes pass at least one content validator."""
+    if not any(v(data) for v in expected_types):
+        logger.warning("Downloaded content failed magic-byte validation")
+        raise UrlPolicyError("URL rejected by fetch policy")
+
+
+async def fetch_file(
+    url: str,
+    policy: UrlFetchPolicy,
+    *,
+    expected_types: tuple[ContentValidator, ...] = (is_pdf,),
+) -> bytes:
+    """Download a user-supplied URL with SSRF protection (async).
+
+    Layers of defense, in order:
+      1. ``validate_url`` (static: proxy mode, scheme, host, IP literal)
+      2. httpx2 request through a wrapped transport that re-validates the
+         resolved destination IP at connect time for every redirect hop
+      3. hard ``max_bytes`` cap, enforced against Content-Length and by
+         counting streamed bytes
+      4. explicit timeouts (``policy.timeout``)
+      5. Content-Type allowlist + at-least-one magic-byte validator
+
+    Args:
+        url: The URL to fetch.
+        policy: The active UrlFetchPolicy.
+        expected_types: Content validators; the body must pass at least one.
+
+    Returns:
+        The downloaded bytes.
+
+    Raises:
+        ProxyRequiredError: If no proxy/direct egress is configured.
+        DownloadSizeExceededError: If the body exceeds ``policy.max_bytes``.
+        UrlPolicyError: If any other policy rule is violated.
+        httpx2.HTTPError: If the network request itself fails.
+    """
+    validate_url(url, policy)
+
+    kwargs = _client_kwargs(policy)
+
+    try:
+        async with (
+            httpx2.AsyncClient(**kwargs) as client,
+            client.stream("GET", url) as response,
+        ):
+            if response.status_code >= 400:
+                logger.warning("HTTP %d fetching %s", response.status_code, url)
+                raise httpx2.HTTPError(f"HTTP {response.status_code} while downloading")
+            _validate_response_headers(response, policy)
+
+            # Pre-check Content-Length when present.
+            content_length = response.headers.get("content-length")
+            if content_length is not None:
+                try:
+                    if int(content_length) > policy.max_bytes:
+                        raise DownloadSizeExceededError(
+                            DownloadSizeExceededError.MESSAGE
+                        )
+                except ValueError:
+                    logger.debug(
+                        "Non-numeric Content-Length %r from %s",
+                        content_length,
+                        url,
+                    )
+
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes(chunk_size=_FETCH_CHUNK_SIZE):
+                total += len(chunk)
+                if total > policy.max_bytes:
+                    logger.warning(
+                        "Download from %s exceeded %d bytes; aborting",
+                        url,
+                        policy.max_bytes,
+                    )
+                    raise DownloadSizeExceededError(DownloadSizeExceededError.MESSAGE)
+                chunks.append(chunk)
+            data = b"".join(chunks)
+    except _BlockedDestinationError as e:
+        logger.warning("Blocked destination during fetch: %s", e)
+        raise UrlPolicyError("URL rejected by fetch policy") from None
+
+    _validate_content(data, expected_types)
+    return data
+
+
+def fetch_file_sync(
+    url: str,
+    policy: UrlFetchPolicy,
+    *,
+    expected_types: tuple[ContentValidator, ...] = (is_pdf,),
+) -> bytes:
+    """Synchronous wrapper around :func:`fetch_file` for the CLI.
+
+    Runs the async fetch on a fresh event loop. Safe to call from a
+    synchronous (non-loop) context such as the Click CLI.
+    """
+
+    async def _run() -> bytes:
+        return await fetch_file(url, policy, expected_types=expected_types)
+
+    return asyncio.run(_run())

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -1,28 +1,13 @@
-"""Network security helpers for fetching user-supplied URLs.
+"""SSRF-hardened fetching of user-supplied URLs.
 
-This module implements BIBRA's SSRF mitigation: a validation layer and a
-hardened fetch function.
+BIBRA's mitigation for the SSRF vector inherent in fetching a user-supplied
+URL: a fetch policy (``UrlFetchPolicy``, loaded from ``BIBRA_URL_*`` env
+vars), static URL validation (``validate_url``) re-applied on every
+redirect hop, and ``fetch_file``, which permits egress only through a
+configured proxy or explicit "direct" mode, checks resolved destination
+IPs at connect time, and enforces size, timeout, and content (PDF) limits.
 
-Validation components:
-    - ``UrlPolicyError``: raised when a URL or downloaded content violates
-      the fetch policy. Carries a safe, generic message suitable for
-      client-facing error responses; full details are logged server-side.
-    - ``is_blocked_ip``: range-table check that refuses private, loopback,
-      link-local (cloud metadata), CGNAT, and other non-public addresses.
-    - ``validate_url``: static validation of a URL against the policy
-      (scheme allowlist, host presence, IP-literal rejection).
-    - ``ContentValidator`` / ``is_pdf``: pluggable byte-level content
-      checks (magic bytes). Currently PDFs are the only supported type;
-      future file types add their own validators.
-
-Fetch components:
-    - ``fetch_file`` / ``fetch_file_sync``: download a user-supplied URL
-      with defense in depth: static URL validation re-applied on every
-      redirect hop, connect-time resolved-IP checking in direct mode
-      (closes DNS-rebinding; in proxy mode the proxy's egress allowlist is
-      the authoritative control), a hard size cap, explicit timeouts, and
-      content-type plus magic-byte verification. Egress is only permitted
-      through a configured proxy or in explicit "direct" mode.
+See the "Security" section of the README for the full model.
 """
 
 import asyncio
@@ -33,7 +18,6 @@ import re
 import socket
 import urllib.parse
 from dataclasses import dataclass
-from typing import Protocol
 
 import httpx2
 
@@ -86,36 +70,20 @@ class UrlFetchPolicy:
         return self.proxy is None
 
 
-def get_url_proxy() -> str | None:
-    """Return the BIBRA_URL_PROXY environment variable value.
-
-    Blank or whitespace-only values are normalized to None, so that
-    callers can safely pass the result to httpx proxy arguments.
-
-    Returns:
-        The proxy URL string, or None if not set or blank.
-    """
-    proxy = os.environ.get("BIBRA_URL_PROXY")
-    return proxy.strip() if proxy and proxy.strip() else None
-
-
 def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
     """Build a UrlFetchPolicy from the BIBRA_URL_* environment variables.
 
-    Semantics of BIBRA_URL_PROXY:
-      - unset/blank: URL fetching is refused (proxy_required is True)
+    Semantics of BIBRA_URL_PROXY (blank/whitespace normalized to unset):
+      - unset: URL fetching is refused (``proxy_required`` is True), unless
+        ``cli_fallback`` is set, in which case "direct" is used instead
       - "direct": direct egress is allowed, subject to full in-app validation
       - anything else: used as the egress proxy URL
-
-    With ``cli_fallback=True`` (the CLI's intent), an unset/blank
-    BIBRA_URL_PROXY is treated as "direct" instead of refusing: the CLI
-    is a local tool and falls back to direct egress with full in-app
-    validation, while the REST API keeps refusing by default.
 
     Invalid numeric/boolean values are logged and replaced by their
     defaults, so that a misconfigured setting never crashes the app.
     """
-    proxy = get_url_proxy()
+    proxy_raw = os.environ.get("BIBRA_URL_PROXY")
+    proxy = proxy_raw.strip() if proxy_raw and proxy_raw.strip() else None
     if proxy is None and cli_fallback:
         proxy = URL_FETCH_DIRECT
     return UrlFetchPolicy(
@@ -194,14 +162,6 @@ class ProxyRequiredError(UrlPolicyError):
     """
 
     MESSAGE = "URL fetching is disabled. Configure BIBRA_URL_PROXY to enable it."
-
-
-class ContentValidator(Protocol):
-    """A byte-level check that a downloaded file is of an expected type."""
-
-    def __call__(self, data: bytes) -> bool:
-        """Return True if data matches the expected content type."""
-        raise NotImplementedError
 
 
 def _normalize_ip(
@@ -412,28 +372,14 @@ async def _check_destination(host: str, port: int | None) -> None:
 def _build_async_transport(
     policy: UrlFetchPolicy, proxy: str | None
 ) -> httpx2.AsyncHTTPTransport:
-    """Build an async transport that validates each request against policy.
-
-    Every request URL is re-checked at connect time via ``validate_url``:
-    scheme allowlist, malformed URL handling, IP-literal rules, numeric-host
-    blocking. Because httpx issues a fresh request through the transport for
-    each redirect hop, every hop is re-validated against the active policy.
-
-    In direct mode (no proxy), an additional resolved-IP check is applied
-    at connect time, which closes the DNS-rebinding window. In proxy mode
-    this check is skipped: the proxy's own egress allowlist is the
-    authoritative control, local ``getaddrinfo`` results may not match the
-    proxy's resolver, and the lookup would only add false positives.
-
-    ``trust_env`` is disabled: the only egress route ever in effect is the
-    explicit ``BIBRA_URL_PROXY`` URL (when one is configured). Ambient
-    ``HTTP_PROXY``/``HTTPS_PROXY``/``NO_PROXY`` environment variables are
-    ignored on purpose, so that egress can never be hijacked by the
-    surrounding environment.
-
-    Args:
-        policy: The active UrlFetchPolicy applied to every request.
-        proxy: Proxy URL to route through, or None for direct egress.
+    """Build an async transport that re-validates every request URL against
+    the policy (each redirect hop issues a fresh request through the
+    transport, so every hop is checked) and, in direct mode, additionally
+    checks the resolved destination IP at connect time to close the
+    DNS-rebinding window (in proxy mode the proxy's egress allowlist is
+    authoritative, and local DNS results may not match its resolver).
+    ``trust_env=False`` ignores ambient HTTP(S)_PROXY/NO_PROXY vars: the
+    only egress route ever in effect is the explicit policy proxy.
     """
     proxy_arg = httpx2.Proxy(proxy) if proxy else None
 
@@ -448,27 +394,6 @@ def _build_async_transport(
             return await super().handle_async_request(request)
 
     return _SafeAsyncTransport(proxy=proxy_arg, trust_env=False)
-
-
-def _client_kwargs(policy: UrlFetchPolicy) -> dict:
-    """Build httpx2 AsyncClient kwargs from the policy.
-
-    The ``transport`` kwarg carries the destination-validating transport;
-    no ``proxy`` kwarg is used so that the client does not also mount its
-    own proxy transport (the proxy, when configured, lives inside our
-    transport).
-    """
-    timeout = httpx2.Timeout(policy.timeout)
-    proxy: str | None = None
-    if policy.proxy is not None and policy.proxy != URL_FETCH_DIRECT:
-        proxy = policy.proxy
-
-    return {
-        "timeout": timeout,
-        "follow_redirects": True,
-        "max_redirects": policy.max_redirects,
-        "transport": _build_async_transport(policy, proxy),
-    }
 
 
 def _validate_response_headers(
@@ -486,46 +411,13 @@ def _validate_response_headers(
         raise UrlPolicyError("URL rejected by fetch policy")
 
 
-def _validate_content(
-    data: bytes, expected_types: tuple[ContentValidator, ...]
-) -> None:
-    """Verify the downloaded bytes pass at least one content validator."""
-    if not any(v(data) for v in expected_types):
-        logger.warning("Downloaded content failed magic-byte validation")
-        raise UrlPolicyError("URL rejected by fetch policy")
+async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
+    """Download a user-supplied PDF with SSRF protection (async).
 
-
-async def fetch_file(
-    url: str,
-    policy: UrlFetchPolicy,
-    *,
-    expected_types: tuple[ContentValidator, ...] = (is_pdf,),
-) -> bytes:
-    """Download a user-supplied URL with SSRF protection (async).
-
-    Layers of defense, in order:
-      1. ``validate_url`` (static: proxy mode, scheme, host, IP literal)
-      2. httpx2 request through a wrapped transport that re-applies the
-         full URL policy for every request, including each redirect hop,
-         and re-checks the resolved destination IP at connect time in
-         direct mode (in proxy mode the proxy's egress allowlist is the
-         authoritative control)
-      3. hard ``max_bytes`` cap, enforced against Content-Length and by
-         counting streamed bytes
-      4. explicit timeouts (``policy.timeout``)
-      5. Content-Type allowlist + at-least-one magic-byte validator
-
-    Ambient ``HTTP_PROXY``/``HTTPS_PROXY`` environment variables are
-    ignored: egress goes only through the policy's explicit proxy (if any)
-    or directly.
-
-    Args:
-        url: The URL to fetch.
-        policy: The active UrlFetchPolicy.
-        expected_types: Content validators; the body must pass at least one.
-
-    Returns:
-        The downloaded bytes.
+    Applies, in order: static URL validation (re-applied on every redirect
+    hop by the transport), connect-time resolved-IP blocking in direct
+    mode, a hard byte cap, explicit timeouts, and a Content-Type allowlist
+    plus magic-byte verification.
 
     Raises:
         ProxyRequiredError: If no proxy/direct egress is configured.
@@ -534,12 +426,16 @@ async def fetch_file(
         httpx2.HTTPError: If the network request itself fails.
     """
     validate_url(url, policy)
-
-    kwargs = _client_kwargs(policy)
+    proxy = policy.proxy if policy.proxy not in (None, URL_FETCH_DIRECT) else None
 
     try:
         async with (
-            httpx2.AsyncClient(**kwargs) as client,
+            httpx2.AsyncClient(
+                timeout=httpx2.Timeout(policy.timeout),
+                follow_redirects=True,
+                max_redirects=policy.max_redirects,
+                transport=_build_async_transport(policy, proxy),
+            ) as client,
             client.stream("GET", url) as response,
         ):
             if response.status_code >= 400:
@@ -582,23 +478,7 @@ async def fetch_file(
         logger.warning("Host resolution failed during fetch: %s", e)
         raise httpx2.ConnectError("Could not resolve host") from None
 
-    _validate_content(data, expected_types)
+    if not is_pdf(data):
+        logger.warning("Downloaded content failed magic-byte validation")
+        raise UrlPolicyError("URL rejected by fetch policy")
     return data
-
-
-def fetch_file_sync(
-    url: str,
-    policy: UrlFetchPolicy,
-    *,
-    expected_types: tuple[ContentValidator, ...] = (is_pdf,),
-) -> bytes:
-    """Synchronous wrapper around :func:`fetch_file` for the CLI.
-
-    Runs the async fetch on a fresh event loop. Safe to call from a
-    synchronous (non-loop) context such as the Click CLI.
-    """
-
-    async def _run() -> bytes:
-        return await fetch_file(url, policy, expected_types=expected_types)
-
-    return asyncio.run(_run())

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -17,11 +17,12 @@ Validation components:
 
 Fetch components:
     - ``fetch_file`` / ``fetch_file_sync``: download a user-supplied URL
-      with defense in depth: static URL validation, connect-time resolved-IP
-      checking (closes DNS-rebinding and covers every redirect hop), a hard
-      size cap, explicit timeouts, and content-type plus magic-byte
-      verification. Egress is only permitted through a configured proxy or in
-      explicit "direct" mode.
+      with defense in depth: static URL validation re-applied on every
+      redirect hop, connect-time resolved-IP checking in direct mode
+      (closes DNS-rebinding; in proxy mode the proxy's egress allowlist is
+      the authoritative control), a hard size cap, explicit timeouts, and
+      content-type plus magic-byte verification. Egress is only permitted
+      through a configured proxy or in explicit "direct" mode.
 """
 
 import asyncio
@@ -316,12 +317,16 @@ def _build_async_transport(
 ) -> httpx2.AsyncHTTPTransport:
     """Build an async transport that validates each request against policy.
 
-    Every request URL is re-checked at connect time: the full static policy
-    (scheme allowlist, malformed URL handling, IP-literal rules, numeric-host
-    blocking) via ``validate_url``, plus a resolved-IP check that closes the
-    DNS-rebinding window. Because httpx issues a fresh request through the
-    transport for each redirect hop, every hop is re-validated against the
-    active policy.
+    Every request URL is re-checked at connect time via ``validate_url``:
+    scheme allowlist, malformed URL handling, IP-literal rules, numeric-host
+    blocking. Because httpx issues a fresh request through the transport for
+    each redirect hop, every hop is re-validated against the active policy.
+
+    In direct mode (no proxy), an additional resolved-IP check is applied
+    at connect time, which closes the DNS-rebinding window. In proxy mode
+    this check is skipped: the proxy's own egress allowlist is the
+    authoritative control, local ``getaddrinfo`` results may not match the
+    proxy's resolver, and the lookup would only add false positives.
 
     ``trust_env`` is disabled: the only egress route ever in effect is the
     explicit ``BIBRA_URL_PROXY`` URL (when one is configured). Ambient
@@ -338,7 +343,11 @@ def _build_async_transport(
     class _SafeAsyncTransport(httpx2.AsyncHTTPTransport):
         async def handle_async_request(self, request: httpx2.Request):
             validate_url(str(request.url), policy)
-            await _check_destination(request.url.host, request.url.port)
+            if proxy is None:
+                # Direct egress: check the resolved destination IP
+                # (closes the DNS-rebinding window). In proxy mode the
+                # proxy's egress allowlist is the authoritative control.
+                await _check_destination(request.url.host, request.url.port)
             return await super().handle_async_request(request)
 
     return _SafeAsyncTransport(proxy=proxy_arg, trust_env=False)
@@ -400,8 +409,10 @@ async def fetch_file(
     Layers of defense, in order:
       1. ``validate_url`` (static: proxy mode, scheme, host, IP literal)
       2. httpx2 request through a wrapped transport that re-applies the
-         full URL policy and re-checks the resolved destination IP at
-         connect time for every request, including each redirect hop
+         full URL policy for every request, including each redirect hop,
+         and re-checks the resolved destination IP at connect time in
+         direct mode (in proxy mode the proxy's egress allowlist is the
+         authoritative control)
       3. hard ``max_bytes`` cap, enforced against Content-Length and by
          counting streamed bytes
       4. explicit timeouts (``policy.timeout``)

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -271,7 +271,7 @@ def redact_url(url: str) -> str:
         if parts.port is not None:
             netloc = f"{netloc}:{parts.port}"
     except ValueError:
-        pass
+        logger.debug("URL has a malformed port; redacting without port")
     return f"{parts.scheme}://{netloc}{parts.path} [userinfo/query/fragment redacted]"
 
 

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -37,6 +37,8 @@ from typing import Protocol
 
 import httpx2
 
+from bibra.env import parse_bool_env, parse_int_env, parse_list_env
+
 logger = logging.getLogger(__name__)
 
 
@@ -84,37 +86,6 @@ class UrlFetchPolicy:
         return self.proxy is None
 
 
-def _parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
-    """Parse a comma-separated env var into a tuple of stripped strings.
-
-    Falls back to the default when the variable is unset or blank.
-    """
-    raw = os.environ.get(name, "")
-    items = [item.strip().lower() for item in raw.split(",") if item.strip()]
-    return tuple(items) if items else tuple(item.lower() for item in default)
-
-
-def _parse_int_env(name: str, default: int) -> int:
-    """Parse a positive-integer env var, falling back to the default."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.debug("Invalid %s=%r; using default %d", name, raw, default)
-        return default
-    return value if value > 0 else default
-
-
-def _parse_bool_env(name: str, default: bool) -> bool:
-    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
-    raw = os.environ.get(name, "").strip().lower()
-    if not raw:
-        return default
-    return raw in {"1", "true", "yes", "on"}
-
-
 def get_url_proxy() -> str | None:
     """Return the BIBRA_URL_PROXY environment variable value.
 
@@ -149,16 +120,16 @@ def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
         proxy = URL_FETCH_DIRECT
     return UrlFetchPolicy(
         proxy=proxy,
-        schemes=_parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
-        content_types=_parse_list_env(
+        schemes=parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
+        content_types=parse_list_env(
             "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES
         ),
-        max_bytes=_parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
-        timeout=_parse_int_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
-        max_redirects=_parse_int_env(
+        max_bytes=parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
+        timeout=parse_int_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
+        max_redirects=parse_int_env(
             "BIBRA_URL_MAX_REDIRECTS", DEFAULT_URL_MAX_REDIRECTS
         ),
-        allow_ip_hosts=_parse_bool_env(
+        allow_ip_hosts=parse_bool_env(
             "BIBRA_URL_ALLOW_IP_HOSTS", DEFAULT_URL_ALLOW_IP_HOSTS
         ),
     )

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -104,7 +104,7 @@ class ContentValidator(Protocol):
 
     def __call__(self, data: bytes) -> bool:
         """Return True if data matches the expected content type."""
-        ...
+        raise NotImplementedError
 
 
 def _normalize_ip(

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -7,6 +7,14 @@ redirect hop, and ``fetch_file``, which permits egress only through a
 configured proxy or explicit "direct" mode, checks resolved destination
 IPs at connect time, and enforces size, timeout, and content (PDF) limits.
 
+Known limitation (direct mode): the destination check resolves the
+hostname once and then the underlying transport resolves it again when
+dialing the socket. A DNS rebinding response between the two lookups
+could swap in a blocked address, so the protection mitigates but does not
+guarantee against DNS rebinding in direct mode. Proxy mode is not
+affected: the proxy's own egress allowlist is the authoritative control.
+In production, prefer configuring BIBRA_URL_PROXY over "direct".
+
 See the "Security" section of the README for the full model.
 """
 
@@ -375,9 +383,12 @@ def _build_async_transport(
     """Build an async transport that re-validates every request URL against
     the policy (each redirect hop issues a fresh request through the
     transport, so every hop is checked) and, in direct mode, additionally
-    checks the resolved destination IP at connect time to close the
-    DNS-rebinding window (in proxy mode the proxy's egress allowlist is
-    authoritative, and local DNS results may not match its resolver).
+    checks the resolved destination IP at request time, which mitigates
+    SSRF and DNS rebinding (see the known-limitation note in the module
+    docstring: the underlying transport resolves the host again when
+    dialing, so the protection is not a guarantee). In proxy mode the
+    proxy's egress allowlist is authoritative, and local DNS results may
+    not match its resolver.
     ``trust_env=False`` ignores ambient HTTP(S)_PROXY/NO_PROXY vars: the
     only egress route ever in effect is the explicit policy proxy.
     """
@@ -388,8 +399,9 @@ def _build_async_transport(
             validate_url(str(request.url), policy)
             if proxy is None:
                 # Direct egress: check the resolved destination IP
-                # (closes the DNS-rebinding window). In proxy mode the
-                # proxy's egress allowlist is the authoritative control.
+                # (mitigates SSRF/DNS rebinding; see module docstring for
+                # the residual TOCTOU window). In proxy mode the proxy's
+                # egress allowlist is the authoritative control.
                 await _check_destination(request.url.host, request.url.port)
             return await super().handle_async_request(request)
 

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -446,6 +446,7 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
                 timeout=httpx2.Timeout(policy.timeout),
                 follow_redirects=True,
                 max_redirects=policy.max_redirects,
+                trust_env=False,
                 transport=_build_async_transport(policy, proxy),
             ) as client,
             client.stream("GET", url) as response,

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -249,16 +249,29 @@ def redact_url(url: str) -> str:
     URLs that carry no userinfo, query, or fragment are returned
     unchanged (byte-identical), and input that cannot be parsed as a
     URL is returned as-is (there is no URL structure to strip).
+
+    Never raises: a malformed port (which makes ``parts.port`` raise
+    ValueError after a successful parse) is logged without a port
+    rather than propagating, so that callers logging on rejection
+    paths cannot be crashed by user input.
     """
     try:
         parts = urllib.parse.urlsplit(url)
     except ValueError:
         return url
-    if not parts.username and not parts.query and not parts.fragment:
+    if (
+        parts.username is None
+        and parts.password is None
+        and not parts.query
+        and not parts.fragment
+    ):
         return url
     netloc = parts.hostname or ""
-    if parts.port is not None:
-        netloc = f"{netloc}:{parts.port}"
+    try:
+        if parts.port is not None:
+            netloc = f"{netloc}:{parts.port}"
+    except ValueError:
+        pass
     return f"{parts.scheme}://{netloc}{parts.path} [userinfo/query/fragment redacted]"
 
 
@@ -291,9 +304,10 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         # The value itself is unused, so discard it into a throwaway name.
         _ = parts.port
     except ValueError:
-        # urlsplit itself failed, or the port was not numeric: redact_url()
-        # returns the input unchanged in the former case and strips any
-        # userinfo/query in the latter.
+        # urlsplit itself failed, or the port was not numeric:
+        # redact_url() never raises — it returns unparseable input
+        # unchanged and, for a malformed port, a redacted host without
+        # a port.
         logger.warning("Malformed URL rejected: %r", safe_url)
         raise UrlPolicyError("URL rejected by fetch policy") from None
 

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -294,20 +294,27 @@ async def _check_destination(host: str, port: int | None) -> None:
             raise _BlockedDestinationError(f"http://{host}", str(ip))
 
 
-def _build_async_transport(proxy: str | None) -> httpx2.AsyncHTTPTransport:
-    """Build an async transport that validates each request's destination.
+def _build_async_transport(
+    policy: UrlFetchPolicy, proxy: str | None
+) -> httpx2.AsyncHTTPTransport:
+    """Build an async transport that validates each request against policy.
 
-    Every request URL's resolved IP is re-checked at connect time, which
-    closes the DNS-rebinding window and covers every redirect hop
-    (httpx issues a fresh request through the transport for each hop).
+    Every request URL is re-checked at connect time: the full static policy
+    (scheme allowlist, malformed URL handling, IP-literal rules, numeric-host
+    blocking) via ``validate_url``, plus a resolved-IP check that closes the
+    DNS-rebinding window. Because httpx issues a fresh request through the
+    transport for each redirect hop, every hop is re-validated against the
+    active policy.
 
     Args:
+        policy: The active UrlFetchPolicy applied to every request.
         proxy: Proxy URL to route through, or None for direct egress.
     """
     proxy_arg = httpx2.Proxy(proxy) if proxy else None
 
     class _SafeAsyncTransport(httpx2.AsyncHTTPTransport):
         async def handle_async_request(self, request: httpx2.Request):
+            validate_url(str(request.url), policy)
             await _check_destination(request.url.host, request.url.port)
             return await super().handle_async_request(request)
 
@@ -331,7 +338,7 @@ def _client_kwargs(policy: UrlFetchPolicy) -> dict:
         "timeout": timeout,
         "follow_redirects": True,
         "max_redirects": policy.max_redirects,
-        "transport": _build_async_transport(proxy),
+        "transport": _build_async_transport(policy, proxy),
     }
 
 
@@ -369,8 +376,9 @@ async def fetch_file(
 
     Layers of defense, in order:
       1. ``validate_url`` (static: proxy mode, scheme, host, IP literal)
-      2. httpx2 request through a wrapped transport that re-validates the
-         resolved destination IP at connect time for every redirect hop
+      2. httpx2 request through a wrapped transport that re-applies the
+         full URL policy and re-checks the resolved destination IP at
+         connect time for every request, including each redirect hop
       3. hard ``max_bytes`` cap, enforced against Content-Length and by
          counting streamed bytes
       4. explicit timeouts (``policy.timeout``)

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -5,7 +5,8 @@ URL: a fetch policy (``UrlFetchPolicy``, loaded from ``BIBRA_URL_*`` env
 vars), static URL validation (``validate_url``) re-applied on every
 redirect hop, and ``fetch_file``, which permits egress only through a
 configured proxy or explicit "direct" mode, checks resolved destination
-IPs at connect time, and enforces size, timeout, and content (PDF) limits.
+IPs at connect time, and enforces size, per-operation timeouts plus a
+total download deadline, and content (PDF) limits.
 
 Known limitation (direct mode): the destination check resolves the
 hostname once and then the underlying transport resolves it again when
@@ -58,7 +59,10 @@ class UrlFetchPolicy:
         schemes: Allowed URL schemes (e.g. ["https"]).
         content_types: Allowed response content types (MIME, no parameters).
         max_bytes: Hard cap on total downloaded bytes.
-        timeout: Whole seconds for connect/read/write/pool timeouts.
+        timeout: Whole seconds for connect/read/write/pool timeouts, and the
+            total deadline for the complete download (a server that drips
+            small chunks to evade the per-read timeout is still aborted
+            once this total deadline elapses).
         max_redirects: Maximum number of redirect hops; every hop is
             re-validated against the policy.
         allow_ip_hosts: Whether URLs whose host is an IP literal are allowed.
@@ -459,13 +463,16 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
 
     Applies, in order: static URL validation (re-applied on every redirect
     hop by the transport), connect-time resolved-IP blocking in direct
-    mode, a hard byte cap, explicit timeouts, and a Content-Type allowlist
-    plus magic-byte verification.
+    mode, a hard byte cap, per-operation timeouts plus a total deadline of
+    ``policy.timeout`` seconds over the complete download (drip-feeding
+    servers that stay under the per-read timeout are still aborted), and a
+    Content-Type allowlist plus magic-byte verification.
 
     Raises:
         ProxyRequiredError: If no proxy/direct egress is configured.
         DownloadSizeExceededError: If the body exceeds ``policy.max_bytes``.
         UrlPolicyError: If any other policy rule is violated.
+        httpx2.ReadTimeout: If the total download deadline is exceeded.
         httpx2.HTTPError: If the network request itself fails.
     """
     safe_url = redact_url(url)
@@ -473,49 +480,73 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
     proxy = policy.proxy if policy.proxy not in (None, URL_FETCH_DIRECT) else None
 
     try:
-        async with (
-            httpx2.AsyncClient(
-                timeout=httpx2.Timeout(policy.timeout),
-                follow_redirects=True,
-                max_redirects=policy.max_redirects,
-                trust_env=False,
-                transport=_build_async_transport(policy, proxy),
-            ) as client,
-            client.stream("GET", url) as response,
-        ):
-            if response.status_code >= 400:
-                logger.warning("HTTP %d fetching %s", response.status_code, safe_url)
-                raise httpx2.HTTPError(f"HTTP {response.status_code} while downloading")
-            _validate_response_headers(response, policy)
+        # The per-operation timeout (connect/read/write/pool) does not bound
+        # the lifetime of the response: a server can send a small chunk just
+        # before every read timeout and keep the fetch alive indefinitely.
+        # asyncio.timeout() enforces a total deadline over the complete
+        # stream; it raises the builtin TimeoutError, which is translated to
+        # httpx2.ReadTimeout below so that callers (API 502 handler, CLI)
+        # keep seeing an httpx2.HTTPError.
+        async with asyncio.timeout(policy.timeout):
+            async with (
+                httpx2.AsyncClient(
+                    timeout=httpx2.Timeout(policy.timeout),
+                    follow_redirects=True,
+                    max_redirects=policy.max_redirects,
+                    trust_env=False,
+                    transport=_build_async_transport(policy, proxy),
+                ) as client,
+                client.stream("GET", url) as response,
+            ):
+                if response.status_code >= 400:
+                    logger.warning(
+                        "HTTP %d fetching %s", response.status_code, safe_url
+                    )
+                    raise httpx2.HTTPError(
+                        f"HTTP {response.status_code} while downloading"
+                    )
+                _validate_response_headers(response, policy)
 
-            # Pre-check Content-Length when present.
-            content_length = response.headers.get("content-length")
-            if content_length is not None:
-                try:
-                    if int(content_length) > policy.max_bytes:
+                # Pre-check Content-Length when present.
+                content_length = response.headers.get("content-length")
+                if content_length is not None:
+                    try:
+                        if int(content_length) > policy.max_bytes:
+                            raise DownloadSizeExceededError(
+                                DownloadSizeExceededError.MESSAGE
+                            )
+                    except ValueError:
+                        logger.debug(
+                            "Non-numeric Content-Length %r from %s",
+                            content_length,
+                            safe_url,
+                        )
+
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes(chunk_size=_FETCH_CHUNK_SIZE):
+                    total += len(chunk)
+                    if total > policy.max_bytes:
+                        logger.warning(
+                            "Download from %s exceeded %d bytes; aborting",
+                            safe_url,
+                            policy.max_bytes,
+                        )
                         raise DownloadSizeExceededError(
                             DownloadSizeExceededError.MESSAGE
                         )
-                except ValueError:
-                    logger.debug(
-                        "Non-numeric Content-Length %r from %s",
-                        content_length,
-                        safe_url,
-                    )
-
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in response.aiter_bytes(chunk_size=_FETCH_CHUNK_SIZE):
-                total += len(chunk)
-                if total > policy.max_bytes:
-                    logger.warning(
-                        "Download from %s exceeded %d bytes; aborting",
-                        safe_url,
-                        policy.max_bytes,
-                    )
-                    raise DownloadSizeExceededError(DownloadSizeExceededError.MESSAGE)
-                chunks.append(chunk)
-            data = b"".join(chunks)
+                    chunks.append(chunk)
+                data = b"".join(chunks)
+    except TimeoutError:
+        # Total deadline exceeded (see the asyncio.timeout note above).
+        logger.warning(
+            "Download of %s exceeded the %ss total deadline",
+            safe_url,
+            policy.timeout,
+        )
+        raise httpx2.ReadTimeout(
+            "Download timed out (total deadline exceeded)"
+        ) from None
     except _BlockedDestinationError as e:
         logger.warning("Blocked destination during fetch: %s", e)
         raise UrlPolicyError("URL rejected by fetch policy") from None

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -355,7 +355,19 @@ def is_pdf(data: bytes) -> bool:
 class DownloadSizeExceededError(UrlPolicyError):
     """Raised when a download exceeds the policy's ``max_bytes`` cap."""
 
-    MESSAGE = "Download rejected by fetch policy"
+    MESSAGE = "Download exceeded the maximum allowed size"
+
+
+class UnsupportedContentTypeError(UrlPolicyError):
+    """Raised when the downloaded file is not a supported type.
+
+    Covers both the Content-Type allowlist check and the content
+    (magic-byte) verification. The message is a fixed constant so it can
+    be shown to API clients without leaking details (see
+    ``UrlPolicyError``).
+    """
+
+    MESSAGE = "Downloaded file is not a supported type"
 
 
 class _BlockedDestinationError(Exception):
@@ -469,7 +481,7 @@ def _validate_response_headers(
             media_type,
             ",".join(policy.content_types),
         )
-        raise UrlPolicyError("URL rejected by fetch policy")
+        raise UnsupportedContentTypeError(UnsupportedContentTypeError.MESSAGE)
 
 
 async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
@@ -485,6 +497,9 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
     Raises:
         ProxyRequiredError: If no proxy/direct egress is configured.
         DownloadSizeExceededError: If the body exceeds ``policy.max_bytes``.
+        UnsupportedContentTypeError: If the response Content-Type is not
+            allowed or the downloaded content fails the file-type
+            verification.
         UrlPolicyError: If any other policy rule is violated.
         httpx2.ReadTimeout: If the total download deadline is exceeded.
         httpx2.HTTPError: If the network request itself fails.
@@ -570,5 +585,5 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
 
     if not is_pdf(data):
         logger.warning("Downloaded content failed magic-byte validation")
-        raise UrlPolicyError("URL rejected by fetch policy")
+        raise UnsupportedContentTypeError(UnsupportedContentTypeError.MESSAGE)
     return data

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -212,13 +212,14 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         logger.warning("URL without host rejected: %s", url)
         raise UrlPolicyError("URL rejected by fetch policy")
 
-    if _NUMERIC_HOST_RE.match(host):
-        # All-numeric hostname (decimal IP obfuscation attempt).
-        logger.warning("Numeric hostname rejected: %s", url)
-        raise UrlPolicyError("URL rejected by fetch policy")
     if is_ip_literal(host):
         ip = parse_ip_host(host)
-        if ip is not None and is_blocked_ip(ip):
+        if ip is None:
+            # All-numeric hostname (decimal IP obfuscation attempt); always
+            # rejected, even when IP literal hosts are otherwise allowed.
+            logger.warning("Numeric hostname rejected: %s", url)
+            raise UrlPolicyError("URL rejected by fetch policy")
+        if is_blocked_ip(ip):
             logger.warning("Blocked IP literal rejected: %s", url)
             raise UrlPolicyError("URL rejected by fetch policy")
         if not policy.allow_ip_hosts:

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -231,6 +231,33 @@ def parse_ip_host(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | 
         return None
 
 
+def redact_url(url: str) -> str:
+    """Return a log-safe representation of a user-supplied URL.
+
+    User-supplied URLs can carry credentials or access tokens in the
+    userinfo component (``user:token@host``) or in the query/fragment
+    strings, so logging the raw URL verbatim would persist secrets in
+    server logs. This helper keeps only ``scheme://host[:port]/path``,
+    which is everything the fetch policy actually inspects, and appends
+    a marker when something was redacted so that operators can tell the
+    logged URL was truncated.
+
+    URLs that carry no userinfo, query, or fragment are returned
+    unchanged (byte-identical), and input that cannot be parsed as a
+    URL is returned as-is (there is no URL structure to strip).
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.username and not parts.query and not parts.fragment:
+        return url
+    netloc = parts.hostname or ""
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    return f"{parts.scheme}://{netloc}{parts.path} [userinfo/query/fragment redacted]"
+
+
 def validate_url(url: str, policy: UrlFetchPolicy) -> None:
     """Statically validate a URL against the fetch policy.
 
@@ -247,8 +274,9 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
             is generic (no hostnames or internal details) so it is safe
             to surface to clients.
     """
+    safe_url = redact_url(url)
     if policy.proxy_required:
-        logger.warning("URL fetch refused (no proxy configured): %s", url)
+        logger.warning("URL fetch refused (no proxy configured): %s", safe_url)
         raise ProxyRequiredError(ProxyRequiredError.MESSAGE)
 
     try:
@@ -259,7 +287,10 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         # The value itself is unused, so discard it into a throwaway name.
         _ = parts.port
     except ValueError:
-        logger.warning("Malformed URL rejected: %r", url)
+        # urlsplit itself failed, or the port was not numeric: redact_url()
+        # returns the input unchanged in the former case and strips any
+        # userinfo/query in the latter.
+        logger.warning("Malformed URL rejected: %r", safe_url)
         raise UrlPolicyError("URL rejected by fetch policy") from None
 
     scheme = (parts.scheme or "").lower()
@@ -268,12 +299,12 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
             "URL scheme %r rejected (allowed: %s): %s",
             scheme,
             ",".join(policy.schemes),
-            url,
+            safe_url,
         )
         raise UrlPolicyError("URL rejected by fetch policy")
 
     if not host:
-        logger.warning("URL without host rejected: %s", url)
+        logger.warning("URL without host rejected: %s", safe_url)
         raise UrlPolicyError("URL rejected by fetch policy")
 
     if is_ip_literal(host):
@@ -281,13 +312,13 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         if ip is None:
             # All-numeric hostname (decimal IP obfuscation attempt); always
             # rejected, even when IP literal hosts are otherwise allowed.
-            logger.warning("Numeric hostname rejected: %s", url)
+            logger.warning("Numeric hostname rejected: %s", safe_url)
             raise UrlPolicyError("URL rejected by fetch policy")
         if is_blocked_ip(ip):
-            logger.warning("Blocked IP literal rejected: %s", url)
+            logger.warning("Blocked IP literal rejected: %s", safe_url)
             raise UrlPolicyError("URL rejected by fetch policy")
         if not policy.allow_ip_hosts:
-            logger.warning("IP literal host rejected: %s", url)
+            logger.warning("IP literal host rejected: %s", safe_url)
             raise UrlPolicyError("URL rejected by fetch policy")
 
 
@@ -437,6 +468,7 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
         UrlPolicyError: If any other policy rule is violated.
         httpx2.HTTPError: If the network request itself fails.
     """
+    safe_url = redact_url(url)
     validate_url(url, policy)
     proxy = policy.proxy if policy.proxy not in (None, URL_FETCH_DIRECT) else None
 
@@ -452,7 +484,7 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
             client.stream("GET", url) as response,
         ):
             if response.status_code >= 400:
-                logger.warning("HTTP %d fetching %s", response.status_code, url)
+                logger.warning("HTTP %d fetching %s", response.status_code, safe_url)
                 raise httpx2.HTTPError(f"HTTP {response.status_code} while downloading")
             _validate_response_headers(response, policy)
 
@@ -468,7 +500,7 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
                     logger.debug(
                         "Non-numeric Content-Length %r from %s",
                         content_length,
-                        url,
+                        safe_url,
                     )
 
             chunks: list[bytes] = []
@@ -478,7 +510,7 @@ async def fetch_file(url: str, policy: UrlFetchPolicy) -> bytes:
                 if total > policy.max_bytes:
                     logger.warning(
                         "Download from %s exceeded %d bytes; aborting",
-                        url,
+                        safe_url,
                         policy.max_bytes,
                     )
                     raise DownloadSizeExceededError(DownloadSizeExceededError.MESSAGE)

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -1,0 +1,221 @@
+"""Network security helpers for fetching user-supplied URLs.
+
+This module implements the validation layer of BIBRA's SSRF mitigation.
+It contains no network I/O; the fetch function built on top of it lives in
+a later step.
+
+Key components:
+    - ``UrlPolicyError``: raised when a URL or downloaded content violates
+      the fetch policy. Carries a safe, generic message suitable for
+      client-facing error responses; full details are logged server-side.
+    - ``is_blocked_ip``: range-table check that refuses private, loopback,
+      link-local (cloud metadata), CGNAT, and other non-public addresses.
+    - ``validate_url``: static validation of a URL against the policy
+      (scheme allowlist, host presence, IP-literal rejection).
+    - ``ContentValidator`` / ``is_pdf``: pluggable byte-level content
+      checks (magic bytes). Currently PDFs are the only supported type;
+      future file types add their own validators.
+"""
+
+import ipaddress
+import logging
+import re
+import urllib.parse
+from typing import Protocol
+
+from bibra.config import UrlFetchPolicy
+
+logger = logging.getLogger(__name__)
+
+#: IPv4 ranges that must never be reachable through user-supplied URLs.
+BLOCKED_IPV4_NETS: tuple[ipaddress.IPv4Network, ...] = (
+    ipaddress.IPv4Network("0.0.0.0/8"),  # "this" network
+    ipaddress.IPv4Network("10.0.0.0/8"),  # private
+    ipaddress.IPv4Network("127.0.0.0/8"),  # loopback
+    ipaddress.IPv4Network("169.254.0.0/16"),  # link-local / cloud metadata
+    ipaddress.IPv4Network("172.16.0.0/12"),  # private
+    ipaddress.IPv4Network("192.168.0.0/16"),  # private
+    ipaddress.IPv4Network("100.64.0.0/10"),  # CGNAT
+    ipaddress.IPv4Network("192.0.0.0/24"),  # IETF protocol assignments
+    ipaddress.IPv4Network("192.0.2.0/24"),  # documentation
+    ipaddress.IPv4Network("198.18.0.0/15"),  # benchmarking
+    ipaddress.IPv4Network("198.51.100.0/24"),  # documentation
+    ipaddress.IPv4Network("203.0.113.0/24"),  # documentation
+    ipaddress.IPv4Network("224.0.0.0/4"),  # multicast
+    ipaddress.IPv4Network("240.0.0.0/4"),  # reserved
+    ipaddress.IPv4Network("255.255.255.255/32"),  # broadcast
+)
+
+#: IPv6 ranges that must never be reachable through user-supplied URLs.
+BLOCKED_IPV6_NETS: tuple[ipaddress.IPv6Network, ...] = (
+    ipaddress.IPv6Network("::/128"),  # unspecified
+    ipaddress.IPv6Network("::1/128"),  # loopback
+    ipaddress.IPv6Network("::ffff:0:0/96"),  # IPv4-mapped
+    ipaddress.IPv6Network("64:ff9b::/96"),  # NAT64
+    ipaddress.IPv6Network("100::/64"),  # discard-only
+    ipaddress.IPv6Network("fc00::/7"),  # unique local
+    ipaddress.IPv6Network("fe80::/10"),  # link-local
+    ipaddress.IPv6Network("ff00::/8"),  # multicast
+)
+
+# Hostnames consisting solely of digits are rejected as possible decimal
+# IP obfuscation (e.g. "2130706433" == 127.0.0.1 on some resolvers).
+_NUMERIC_HOST_RE = re.compile(r"^\d+$")
+
+
+class UrlPolicyError(Exception):
+    """Raised when a URL or downloaded content violates the fetch policy.
+
+    The exception message is intentionally generic so that it can be
+    shown to API clients without leaking internal details (hostnames,
+    resolved IPs, redirect targets). Full context is logged by the
+    raising code before re-raising or converting to a client error.
+    """
+
+
+class ProxyRequiredError(UrlPolicyError):
+    """Raised when URL fetching is attempted while no proxy/direct is set.
+
+    Distinguished from ``UrlPolicyError`` so callers can map it to a
+    503 "service unavailable" (configuration issue) rather than a 400
+    (client-supplied URL rejected).
+    """
+
+    MESSAGE = "URL fetching is disabled. Configure BIBRA_URL_PROXY to enable it."
+
+
+class ContentValidator(Protocol):
+    """A byte-level check that a downloaded file is of an expected type."""
+
+    def __call__(self, data: bytes) -> bool:
+        """Return True if data matches the expected content type."""
+        ...
+
+
+def _normalize_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:10.0.0.1)."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+def is_blocked_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True if the IP address is in a blocked (non-public) range.
+
+    IPv4-mapped IPv6 addresses are unwrapped before checking so that
+    e.g. ``::ffff:127.0.0.1`` is blocked just like ``127.0.0.1``.
+    """
+    ip = _normalize_ip(ip)
+    if isinstance(ip, ipaddress.IPv4Address):
+        return any(ip in net for net in BLOCKED_IPV4_NETS)
+    return any(ip in net for net in BLOCKED_IPV6_NETS)
+
+
+def is_ip_literal(host: str) -> bool:
+    """Return True if the hostname is (or looks like) an IP literal.
+
+    Recognizes standard IPv4/IPv6 literals, bracketed IPv6 (the URL
+    form), and all-numeric hostnames that some resolvers accept as
+    decimal IPv4 obfuscation.
+    """
+    candidate = host.strip()
+    if not candidate:
+        return False
+    # Bracketed IPv6 form, e.g. "[::1]"
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    if _NUMERIC_HOST_RE.match(candidate):
+        return True
+    try:
+        ipaddress.ip_address(candidate)
+        return True
+    except ValueError:
+        return False
+
+
+def parse_ip_host(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse a hostname as an IP address, or return None if not parseable.
+
+    Handles bracketed IPv6 and unwraps IPv4-mapped IPv6 addresses.
+    """
+    candidate = host.strip()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        return _normalize_ip(ipaddress.ip_address(candidate))
+    except ValueError:
+        return None
+
+
+def validate_url(url: str, policy: UrlFetchPolicy) -> None:
+    """Statically validate a URL against the fetch policy.
+
+    This is a pre-flight check performed before any network activity
+    (and again on every redirect hop). It does not resolve hostnames;
+    the connect-time check of resolved IPs is a separate layer.
+
+    Args:
+        url: The URL to validate.
+        policy: The active UrlFetchPolicy.
+
+    Raises:
+        UrlPolicyError: If the URL violates any policy rule. The message
+            is generic (no hostnames or internal details) so it is safe
+            to surface to clients.
+    """
+    if policy.proxy_required:
+        logger.warning("URL fetch refused (no proxy configured): %s", url)
+        raise ProxyRequiredError(ProxyRequiredError.MESSAGE)
+
+    try:
+        parts = urllib.parse.urlsplit(url)
+        host = parts.hostname or ""
+        # Accessing .port raises ValueError for non-numeric or
+        # out-of-range ports; treat those as malformed URLs.
+        _port = parts.port
+    except ValueError:
+        logger.warning("Malformed URL rejected: %r", url)
+        raise UrlPolicyError("URL rejected by fetch policy") from None
+
+    scheme = (parts.scheme or "").lower()
+    if scheme not in policy.schemes:
+        logger.warning(
+            "URL scheme %r rejected (allowed: %s): %s",
+            scheme,
+            ",".join(policy.schemes),
+            url,
+        )
+        raise UrlPolicyError("URL rejected by fetch policy")
+
+    if not host:
+        logger.warning("URL without host rejected: %s", url)
+        raise UrlPolicyError("URL rejected by fetch policy")
+
+    ip = parse_ip_host(host)
+    if ip is not None:
+        if is_blocked_ip(ip):
+            logger.warning("Blocked IP literal rejected: %s", url)
+            raise UrlPolicyError("URL rejected by fetch policy")
+        if not policy.allow_ip_hosts:
+            logger.warning("IP literal host rejected: %s", url)
+            raise UrlPolicyError("URL rejected by fetch policy")
+    elif _NUMERIC_HOST_RE.match(host):
+        # All-numeric hostname (decimal IP obfuscation attempt).
+        logger.warning("Numeric hostname rejected: %s", url)
+        raise UrlPolicyError("URL rejected by fetch policy")
+
+
+def is_pdf(data: bytes) -> bool:
+    """Return True if the byte string looks like a PDF file.
+
+    Searches for the ``%PDF`` magic signature within the first 1024
+    bytes, which matches PDF reader behaviour: some producers emit
+    a preamble (whitespace, a UTF-8 BOM, or other junk) before the
+    header, and spec-compliant readers locate the header within the
+    first 1024 bytes of the file.
+    """
+    return b"%PDF" in data[:1024]

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -191,7 +191,8 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         host = parts.hostname or ""
         # Accessing .port raises ValueError for non-numeric or
         # out-of-range ports; treat those as malformed URLs.
-        _port = parts.port
+        # The value itself is unused, so discard it into a throwaway name.
+        _ = parts.port
     except ValueError:
         logger.warning("Malformed URL rejected: %r", url)
         raise UrlPolicyError("URL rejected by fetch policy") from None

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -256,13 +256,30 @@ class _BlockedDestinationError(Exception):
         self.ip = ip
 
 
+class _DnsResolutionError(Exception):
+    """Internal: a hostname could not be resolved locally.
+
+    Not a policy violation — the host simply does not resolve (typo,
+    offline). Translated to a connection error (502 at the API level)
+    rather than a fetch-policy rejection (400).
+    """
+
+    def __init__(self, url: str):
+        super().__init__(f"could not resolve host for {url}")
+        self.url = url
+
+
 async def _check_destination(host: str, port: int | None) -> None:
-    """Raise _BlockedDestinationError if any resolved IP is blocked.
+    """Raise _BlockedDestinationError or _DnsResolutionError on failure.
 
     Resolves the hostname on the running event loop (non-blocking) and
     checks every address a connection could hit, which enforces the
     blocked-IP policy at connect time and mitigates DNS rebinding.
     IP literals are checked directly without a DNS lookup.
+
+    Raises:
+        _BlockedDestinationError: If any resolved IP is blocked.
+        _DnsResolutionError: If the hostname does not resolve at all.
     """
     literal = parse_ip_host(host)
     if literal is not None:
@@ -282,7 +299,7 @@ async def _check_destination(host: str, port: int | None) -> None:
         )
     except socket.gaierror as e:
         logger.warning("DNS resolution failed for %s: %s", host, e)
-        raise _BlockedDestinationError(f"http://{host}", "unresolvable") from None
+        raise _DnsResolutionError(f"http://{host}") from None
     seen: set[str] = set()
     for info in infos:
         ip_str = info[4][0]
@@ -453,6 +470,9 @@ async def fetch_file(
     except _BlockedDestinationError as e:
         logger.warning("Blocked destination during fetch: %s", e)
         raise UrlPolicyError("URL rejected by fetch policy") from None
+    except _DnsResolutionError as e:
+        logger.warning("Host resolution failed during fetch: %s", e)
+        raise httpx2.ConnectError("Could not resolve host") from None
 
     _validate_content(data, expected_types)
     return data

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -28,16 +28,141 @@ Fetch components:
 import asyncio
 import ipaddress
 import logging
+import os
 import re
 import socket
 import urllib.parse
+from dataclasses import dataclass
 from typing import Protocol
 
 import httpx2
 
-from bibra.config import URL_FETCH_DIRECT, UrlFetchPolicy
-
 logger = logging.getLogger(__name__)
+
+
+# Sentinel value for BIBRA_URL_PROXY meaning "fetch directly, with the
+# full in-app URL validation". Any other non-blank value is treated as a
+# proxy URL; a blank/unset value means URL fetching is refused entirely.
+URL_FETCH_DIRECT = "direct"
+
+# Defaults for the URL fetch policy (BIBRA_URL_* env vars).
+DEFAULT_URL_SCHEMES: list[str] = ["https"]
+DEFAULT_URL_CONTENT_TYPES: list[str] = ["application/pdf"]
+DEFAULT_URL_MAX_BYTES: int = 50 * 1024 * 1024  # 50 MiB
+DEFAULT_URL_TIMEOUT: int = 30  # seconds
+DEFAULT_URL_MAX_REDIRECTS: int = 5
+DEFAULT_URL_ALLOW_IP_HOSTS: bool = False
+
+
+@dataclass(frozen=True)
+class UrlFetchPolicy:
+    """Policy governing how BIBRA fetches user-supplied URLs (SSRF hardening).
+
+    Attributes:
+        proxy: The egress proxy URL, the literal sentinel "direct" (see
+            URL_FETCH_DIRECT) for direct egress, or None to refuse fetching.
+        schemes: Allowed URL schemes (e.g. ["https"]).
+        content_types: Allowed response content types (MIME, no parameters).
+        max_bytes: Hard cap on total downloaded bytes.
+        timeout: Whole seconds for connect/read/write/pool timeouts.
+        max_redirects: Maximum number of redirect hops; every hop is
+            re-validated against the policy.
+        allow_ip_hosts: Whether URLs whose host is an IP literal are allowed.
+    """
+
+    proxy: str | None
+    schemes: tuple[str, ...]
+    content_types: tuple[str, ...]
+    max_bytes: int
+    timeout: int
+    max_redirects: int
+    allow_ip_hosts: bool
+
+    @property
+    def proxy_required(self) -> bool:
+        """True when URL fetching must be refused (no proxy or direct set)."""
+        return self.proxy is None
+
+
+def _parse_list_env(name: str, default: list[str]) -> tuple[str, ...]:
+    """Parse a comma-separated env var into a tuple of stripped strings.
+
+    Falls back to the default when the variable is unset or blank.
+    """
+    raw = os.environ.get(name, "")
+    items = [item.strip().lower() for item in raw.split(",") if item.strip()]
+    return tuple(items) if items else tuple(item.lower() for item in default)
+
+
+def _parse_int_env(name: str, default: int) -> int:
+    """Parse a positive-integer env var, falling back to the default."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.debug("Invalid %s=%r; using default %d", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    """Parse a boolean env var (1/true/yes/on), falling back to the default."""
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
+def get_url_proxy() -> str | None:
+    """Return the BIBRA_URL_PROXY environment variable value.
+
+    Blank or whitespace-only values are normalized to None, so that
+    callers can safely pass the result to httpx proxy arguments.
+
+    Returns:
+        The proxy URL string, or None if not set or blank.
+    """
+    proxy = os.environ.get("BIBRA_URL_PROXY")
+    return proxy.strip() if proxy and proxy.strip() else None
+
+
+def load_url_fetch_policy(cli_fallback: bool = False) -> UrlFetchPolicy:
+    """Build a UrlFetchPolicy from the BIBRA_URL_* environment variables.
+
+    Semantics of BIBRA_URL_PROXY:
+      - unset/blank: URL fetching is refused (proxy_required is True)
+      - "direct": direct egress is allowed, subject to full in-app validation
+      - anything else: used as the egress proxy URL
+
+    With ``cli_fallback=True`` (the CLI's intent), an unset/blank
+    BIBRA_URL_PROXY is treated as "direct" instead of refusing: the CLI
+    is a local tool and falls back to direct egress with full in-app
+    validation, while the REST API keeps refusing by default.
+
+    Invalid numeric/boolean values are logged and replaced by their
+    defaults, so that a misconfigured setting never crashes the app.
+    """
+    proxy = get_url_proxy()
+    if proxy is None and cli_fallback:
+        proxy = URL_FETCH_DIRECT
+    return UrlFetchPolicy(
+        proxy=proxy,
+        schemes=_parse_list_env("BIBRA_URL_SCHEMES", DEFAULT_URL_SCHEMES),
+        content_types=_parse_list_env(
+            "BIBRA_URL_CONTENT_TYPES", DEFAULT_URL_CONTENT_TYPES
+        ),
+        max_bytes=_parse_int_env("BIBRA_URL_MAX_BYTES", DEFAULT_URL_MAX_BYTES),
+        timeout=_parse_int_env("BIBRA_URL_TIMEOUT", DEFAULT_URL_TIMEOUT),
+        max_redirects=_parse_int_env(
+            "BIBRA_URL_MAX_REDIRECTS", DEFAULT_URL_MAX_REDIRECTS
+        ),
+        allow_ip_hosts=_parse_bool_env(
+            "BIBRA_URL_ALLOW_IP_HOSTS", DEFAULT_URL_ALLOW_IP_HOSTS
+        ),
+    )
+
 
 #: Read the response body in chunks no larger than this while enforcing the
 #: size cap, so we can abort mid-stream without buffering unbounded data.

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -306,6 +306,12 @@ def _build_async_transport(
     transport for each redirect hop, every hop is re-validated against the
     active policy.
 
+    ``trust_env`` is disabled: the only egress route ever in effect is the
+    explicit ``BIBRA_URL_PROXY`` URL (when one is configured). Ambient
+    ``HTTP_PROXY``/``HTTPS_PROXY``/``NO_PROXY`` environment variables are
+    ignored on purpose, so that egress can never be hijacked by the
+    surrounding environment.
+
     Args:
         policy: The active UrlFetchPolicy applied to every request.
         proxy: Proxy URL to route through, or None for direct egress.
@@ -318,7 +324,7 @@ def _build_async_transport(
             await _check_destination(request.url.host, request.url.port)
             return await super().handle_async_request(request)
 
-    return _SafeAsyncTransport(proxy=proxy_arg)
+    return _SafeAsyncTransport(proxy=proxy_arg, trust_env=False)
 
 
 def _client_kwargs(policy: UrlFetchPolicy) -> dict:
@@ -383,6 +389,10 @@ async def fetch_file(
          counting streamed bytes
       4. explicit timeouts (``policy.timeout``)
       5. Content-Type allowlist + at-least-one magic-byte validator
+
+    Ambient ``HTTP_PROXY``/``HTTPS_PROXY`` environment variables are
+    ignored: egress goes only through the policy's explicit proxy (if any)
+    or directly.
 
     Args:
         url: The URL to fetch.

--- a/bibra/net_security.py
+++ b/bibra/net_security.py
@@ -211,18 +211,18 @@ def validate_url(url: str, policy: UrlFetchPolicy) -> None:
         logger.warning("URL without host rejected: %s", url)
         raise UrlPolicyError("URL rejected by fetch policy")
 
-    ip = parse_ip_host(host)
-    if ip is not None:
-        if is_blocked_ip(ip):
+    if _NUMERIC_HOST_RE.match(host):
+        # All-numeric hostname (decimal IP obfuscation attempt).
+        logger.warning("Numeric hostname rejected: %s", url)
+        raise UrlPolicyError("URL rejected by fetch policy")
+    if is_ip_literal(host):
+        ip = parse_ip_host(host)
+        if ip is not None and is_blocked_ip(ip):
             logger.warning("Blocked IP literal rejected: %s", url)
             raise UrlPolicyError("URL rejected by fetch policy")
         if not policy.allow_ip_hosts:
             logger.warning("IP literal host rejected: %s", url)
             raise UrlPolicyError("URL rejected by fetch policy")
-    elif _NUMERIC_HOST_RE.match(host):
-        # All-numeric hostname (decimal IP obfuscation attempt).
-        logger.warning("Numeric hostname rejected: %s", url)
-        raise UrlPolicyError("URL rejected by fetch policy")
 
 
 def is_pdf(data: bytes) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pymupdf4llm>=1.27.2",
     "regex>=2026.5.9",
     "tiktoken>=0.12.0",
+    "httpx2>=2.12.0",
 ]
 
 [project.scripts]
@@ -58,7 +59,6 @@ documentation = "https://github.com/NatLibFi/BIBRA/wiki"
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.0.0",
-    "httpx>=0.28.0",
     "pytest-cov>=7.0.0",
     "ruff~=0.16.0",
     "pre-commit>=4.6.0",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -101,6 +101,8 @@ class TestAPIRoutes:
     async def test_extract_url_returns_example_metadata(self):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""
+        from pydantic import HttpUrl
+
         registry = ProjectRegistry()
 
         # Mock httpx.AsyncClient stream response
@@ -124,7 +126,7 @@ class TestAPIRoutes:
             result = await extract_url(
                 project_id="dummy",
                 registry=registry,
-                urls=["https://example.com/paper.pdf"],
+                url=HttpUrl("https://example.com/paper.pdf"),
             )
 
         assert isinstance(result, PublicationMetadata)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,6 +1,6 @@
 """Tests for API routes."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException, Request
@@ -8,6 +8,7 @@ from fastapi.routing import APIRoute
 
 from bibra.api.v0.routes import (
     extract,
+    extract_url,
     get_registry,
     list_projects,
     router,
@@ -75,6 +76,60 @@ class TestAPIRoutes:
         assert result.e_isbn == ["978-0-123456-78-9"]
         assert result.type_coar == "article"
 
+        # Verify fields that don't have values are None or empty lists
+        assert result.alt_title is None
+        assert result.p_isbn == []
+        assert result.e_issn is None
+
+    def test_extract_url_route_exists(self):
+        """The router should have a project-specific extract-url route."""
+        routes = [str(r.path) for r in router.routes]
+        assert "/projects/{project_id}/extract-url" in routes
+
+    def test_extract_url_route_is_post_method(self):
+        """The extract-url route should use POST method."""
+        extract_url_routes = [
+            r
+            for r in router.routes
+            if str(r.path) == "/projects/{project_id}/extract-url"
+        ]
+        assert len(extract_url_routes) >= 1
+        # Check that the route uses POST method
+        route = extract_url_routes[0]
+        assert isinstance(route, APIRoute)
+
+    async def test_extract_returns_example_metadata(self):
+        """The /projects/{project_id}/extract-url endpoint should return example
+        publication metadata."""
+        registry = ProjectRegistry()
+
+        # Mock pdf file download
+        mock_response = MagicMock()
+        mock_response.info.return_value.get_content_type.return_value = (
+            "application/pdf"
+        )
+        mock_response.read.side_effect = [b"%PDF-1.4 mock content", b""]
+        mock_response.__enter__.return_value = mock_response
+        mock_response.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = await extract_url(
+                project_id="dummy",
+                registry=registry,
+                urls=["https://example.com/paper.pdf"],
+            )
+
+        assert isinstance(result, PublicationMetadata)
+        assert result.language == "en"
+        assert (
+            result.title == "Machine Learning Approaches for Software Defect Prediction"
+        )
+        assert result.creator == ["Smith, John", "Johnson, Emily"]
+        assert result.year == "2023"
+        assert result.publisher == ["Springer", "ACM"]
+        assert result.doi == "10.1234/example.doi.12345"
+        assert result.e_isbn == ["978-0-123456-78-9"]
+        assert result.type_coar == "article"
         # Verify fields that don't have values are None or empty lists
         assert result.alt_title is None
         assert result.p_isbn == []

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -217,3 +217,65 @@ class TestAPIRoutes:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Project 'unknown' not found"
+
+    async def test_extract_url_passes_proxy_when_set(self, monkeypatch):
+        """Test that extract-url passes the proxy to httpx.AsyncClient when set."""
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+
+        registry = ProjectRegistry()
+
+        async def mock_aiter_bytes(*args, **kwargs):
+            yield b"%PDF-1.4 mock content"
+
+        mock_response = MagicMock()
+        mock_response.headers = Headers({"content-type": "application/pdf"})
+        mock_response.status_code = 200
+        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+            result = await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("https://example.com/paper.pdf"),
+            )
+
+        mock_client_cls.assert_called_once_with(proxy="http://proxy.example.com:8080")
+        assert isinstance(result, PublicationMetadata)
+
+    async def test_extract_url_no_proxy_when_not_set(self, monkeypatch):
+        """Test that extract-url passes proxy=None when env var is not set."""
+        from pydantic import HttpUrl
+
+        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
+
+        registry = ProjectRegistry()
+
+        async def mock_aiter_bytes(*args, **kwargs):
+            yield b"%PDF-1.4 mock content"
+
+        mock_response = MagicMock()
+        mock_response.headers = Headers({"content-type": "application/pdf"})
+        mock_response.status_code = 200
+        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+            result = await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("https://example.com/paper.pdf"),
+            )
+
+        mock_client_cls.assert_called_once_with(proxy=None)
+        assert isinstance(result, PublicationMetadata)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,10 +1,11 @@
 """Tests for API routes."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
+from httpx import Headers
 
 from bibra.api.v0.routes import (
     extract,
@@ -105,23 +106,19 @@ class TestAPIRoutes:
 
         registry = ProjectRegistry()
 
-        # Mock httpx.AsyncClient stream response
-        mock_response = MagicMock()
-        mock_response.headers.get.return_value = "application/pdf"
-        mock_response.status_code = 200
-
         async def mock_aiter_bytes(*args, **kwargs):
             yield b"%PDF-1.4 mock content"
 
+        mock_response = MagicMock()
+        mock_response.headers = Headers({"content-type": "application/pdf"})
+        mock_response.status_code = 200
         mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-        mock_response.__aenter__.return_value = mock_response
-        mock_response.__aexit__.return_value = False
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = MagicMock()
-            mock_client.__aenter__.return_value = mock_client
-            mock_client.__aexit__.return_value = False
-            mock_client.stream = MagicMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
             mock_client_cls.return_value = mock_client
             result = await extract_url(
                 project_id="dummy",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -98,21 +98,29 @@ class TestAPIRoutes:
         route = extract_url_routes[0]
         assert isinstance(route, APIRoute)
 
-    async def test_extract_returns_example_metadata(self):
+    async def test_extract_url_returns_example_metadata(self):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""
         registry = ProjectRegistry()
 
-        # Mock pdf file download
+        # Mock httpx.AsyncClient stream response
         mock_response = MagicMock()
-        mock_response.info.return_value.get_content_type.return_value = (
-            "application/pdf"
-        )
-        mock_response.read.side_effect = [b"%PDF-1.4 mock content", b""]
-        mock_response.__enter__.return_value = mock_response
-        mock_response.__exit__.return_value = False
+        mock_response.headers.get.return_value = "application/pdf"
+        mock_response.status_code = 200
 
-        with patch("urllib.request.urlopen", return_value=mock_response):
+        async def mock_aiter_bytes(*args, **kwargs):
+            yield b"%PDF-1.4 mock content"
+
+        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
+        mock_response.__aenter__.return_value = mock_response
+        mock_response.__aexit__.return_value = False
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = False
+            mock_client.stream = MagicMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
             result = await extract_url(
                 project_id="dummy",
                 registry=registry,

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -2,10 +2,10 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx2
 import pytest
 from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
-from httpx2 import Headers
 
 from bibra.api.v0.routes import (
     extract,
@@ -15,34 +15,8 @@ from bibra.api.v0.routes import (
     router,
 )
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.net_security import ProxyRequiredError, UrlPolicyError
 from bibra.types import PublicationMetadata
-
-
-def _make_stream_client_mock():
-    """Build a mock httpx2.AsyncClient matching extract_url()'s streaming usage.
-
-    The mock supports ``async with client as c: async with c.stream(...) as r``
-    and yields a single PDF-like byte chunk from ``r.aiter_bytes()``.
-    """
-
-    async def mock_aiter_bytes(*args, **kwargs):
-        yield b"%PDF-1.4 mock content"
-
-    mock_response = MagicMock()
-    mock_response.headers = Headers({"content-type": "application/pdf"})
-    mock_response.status_code = 200
-    mock_response.reason_phrase = "OK"
-    mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-
-    mock_stream_cm = MagicMock()
-    mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
-    mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
-
-    mock_client = MagicMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.stream.return_value = mock_stream_cm
-    return mock_client
 
 
 class TestAPIRoutes:
@@ -125,21 +99,28 @@ class TestAPIRoutes:
         assert isinstance(route, APIRoute)
         assert "POST" in route.methods
 
-    async def test_extract_url_returns_example_metadata(self):
+    async def test_extract_url_returns_example_metadata(self, monkeypatch):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""
         from pydantic import HttpUrl
 
         registry = ProjectRegistry()
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
 
-        with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = _make_stream_client_mock()
-            mock_client_cls.return_value = mock_client
+        with patch(
+            "bibra.api.v0.routes.fetch_file",
+            new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
+        ) as mock_fetch:
             result = await extract_url(
                 project_id="dummy",
                 registry=registry,
                 url=HttpUrl("https://example.com/paper.pdf"),
             )
+
+        mock_fetch.assert_awaited_once()
+        args, _ = mock_fetch.call_args
+        assert args[0] == "https://example.com/paper.pdf"
+        assert args[1].proxy == "direct"
 
         assert isinstance(result, PublicationMetadata)
         assert result.language == "en"
@@ -233,42 +214,130 @@ class TestAPIRoutes:
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Project 'unknown' not found"
 
-    async def test_extract_url_passes_proxy_when_set(self, monkeypatch):
-        """Test that extract-url passes the proxy to httpx2.AsyncClient when set."""
+    async def test_extract_url_uses_configured_proxy(self, monkeypatch):
+        """The fetch policy passed to fetch_file carries the configured proxy."""
         from pydantic import HttpUrl
 
         monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
 
         registry = ProjectRegistry()
 
-        with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = _make_stream_client_mock()
-            mock_client_cls.return_value = mock_client
+        with patch(
+            "bibra.api.v0.routes.fetch_file",
+            new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
+        ) as mock_fetch:
             result = await extract_url(
                 project_id="dummy",
                 registry=registry,
                 url=HttpUrl("https://example.com/paper.pdf"),
             )
 
-        mock_client_cls.assert_called_once_with(proxy="http://proxy.example.com:8080")
+        args, _ = mock_fetch.call_args
+        assert args[1].proxy == "http://proxy.example.com:8080"
         assert isinstance(result, PublicationMetadata)
 
-    async def test_extract_url_no_proxy_when_not_set(self, monkeypatch):
-        """Test that extract-url passes proxy=None when env var is not set."""
+    async def test_extract_url_refused_when_proxy_not_set(self, monkeypatch):
+        """With no proxy/direct configured the endpoint returns 503."""
         from pydantic import HttpUrl
 
         monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
 
         registry = ProjectRegistry()
 
-        with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = _make_stream_client_mock()
-            mock_client_cls.return_value = mock_client
-            result = await extract_url(
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file",
+                new=AsyncMock(
+                    side_effect=ProxyRequiredError(ProxyRequiredError.MESSAGE)
+                ),
+            ) as mock_fetch,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await extract_url(
                 project_id="dummy",
                 registry=registry,
                 url=HttpUrl("https://example.com/paper.pdf"),
             )
 
-        mock_client_cls.assert_called_once_with(proxy=None)
-        assert isinstance(result, PublicationMetadata)
+        mock_fetch.assert_awaited_once()
+        assert exc_info.value.status_code == 503
+        assert "BIBRA_URL_PROXY" in exc_info.value.detail
+
+    async def test_extract_url_policy_error_returns_400(self, monkeypatch):
+        """A URL rejected by the fetch policy returns 400 with a generic detail."""
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        registry = ProjectRegistry()
+
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file",
+                new=AsyncMock(
+                    side_effect=UrlPolicyError("URL rejected by fetch policy")
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("http://169.254.169.254/latest/meta-data/"),
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "169.254.169.254" not in exc_info.value.detail
+
+    async def test_extract_url_http_error_returns_502(self, monkeypatch):
+        """A failed download returns 502 without leaking internal details."""
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        registry = ProjectRegistry()
+
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file",
+                new=AsyncMock(
+                    side_effect=httpx2.HTTPError("connection refused to internal host")
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("https://example.com/paper.pdf"),
+            )
+
+        assert exc_info.value.status_code == 502
+        assert "internal" not in exc_info.value.detail
+
+    async def test_extract_url_cleanup_temp_file_on_backend_error(self, monkeypatch):
+        """The temporary file is removed even if the backend raises."""
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        registry = ProjectRegistry()
+        mock_backend = MagicMock()
+        mock_backend.extract = AsyncMock(side_effect=RuntimeError("boom"))
+        registry.get_backend = MagicMock(return_value=mock_backend)
+
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file",
+                new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
+            ),
+            patch("bibra.api.v0.routes.os.unlink") as mock_unlink,
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("https://example.com/paper.pdf"),
+            )
+
+        mock_unlink.assert_called_once()

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -289,6 +289,32 @@ class TestAPIRoutes:
         assert exc_info.value.status_code == 400
         assert "169.254.169.254" not in exc_info.value.detail
 
+    async def test_extract_url_dns_failure_returns_502(self, monkeypatch):
+        """A hostname that does not resolve returns 502, not a 400 policy rejection."""
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        registry = ProjectRegistry()
+
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file",
+                new=AsyncMock(
+                    side_effect=httpx2.ConnectError("Could not resolve host")
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await extract_url(
+                project_id="dummy",
+                registry=registry,
+                url=HttpUrl("https://nonexistent-host.invalid/paper.pdf"),
+            )
+
+        assert exc_info.value.status_code == 502
+        assert exc_info.value.detail == "Failed to download URL"
+
     async def test_extract_url_http_error_returns_502(self, monkeypatch):
         """A failed download returns 502 without leaking internal details."""
         from pydantic import HttpUrl

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -97,6 +97,7 @@ class TestAPIRoutes:
         route = extract_url_routes[0]
         assert isinstance(route, APIRoute)
         assert "POST" in route.methods
+
     async def test_extract_url_returns_example_metadata(self):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -345,11 +345,17 @@ class TestAPIRoutes:
         """The temporary file is removed even if the backend raises."""
         from pydantic import HttpUrl
 
+        from bibra.backend.base import BaseBackend
+
         monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
 
         registry = ProjectRegistry()
         mock_backend = MagicMock()
         mock_backend.extract = AsyncMock(side_effect=RuntimeError("boom"))
+        # Bind the real helper so the temp-file write/cleanup runs.
+        mock_backend.extract_from_bytes = BaseBackend.extract_from_bytes.__get__(
+            mock_backend, type(mock_backend)
+        )
         registry.get_backend = MagicMock(return_value=mock_backend)
 
         with (
@@ -357,7 +363,7 @@ class TestAPIRoutes:
                 "bibra.api.v0.routes.fetch_file",
                 new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
             ),
-            patch("bibra.api.v0.routes.os.unlink") as mock_unlink,
+            patch("bibra.backend.base.os.unlink") as mock_unlink,
             pytest.raises(RuntimeError, match="boom"),
         ):
             await extract_url(

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -6,6 +6,7 @@ import httpx2
 import pytest
 from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
+from pydantic import HttpUrl
 
 from bibra.api.v0.routes import (
     extract,
@@ -14,27 +15,92 @@ from bibra.api.v0.routes import (
     list_projects,
     router,
 )
-from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
+from bibra.backend.base import BaseBackend
+from bibra.config import (
+    ConfigError,
+    ConfigFileNotFoundError,
+    ProjectNotFoundError,
+    ProjectRegistry,
+)
 from bibra.net_security import ProxyRequiredError, UrlPolicyError
 from bibra.types import PublicationMetadata
+
+MOCK_PDF_BYTES = b"%PDF-1.4 mock content"
+DUMMY_URL = HttpUrl("https://example.com/paper.pdf")
+
+
+def assert_dummy_metadata(result):
+    """Assert the result equals the dummy backend's fixed example metadata."""
+    assert isinstance(result, PublicationMetadata)
+    assert result.language == "en"
+    assert result.title == "Machine Learning Approaches for Software Defect Prediction"
+    assert result.creator == ["Smith, John", "Johnson, Emily"]
+    assert result.year == "2023"
+    assert result.publisher == ["Springer", "ACM"]
+    assert result.doi == "10.1234/example.doi.12345"
+    assert result.e_isbn == ["978-0-123456-78-9"]
+    assert result.type_coar == "article"
+    # Verify fields that don't have values are None or empty lists
+    assert result.alt_title is None
+    assert result.p_isbn == []
+    assert result.e_issn is None
+
+
+async def _call_extract_url(monkeypatch, proxy, url, side_effect=None):
+    """Configure the proxy env and mock fetch_file, then call extract_url.
+
+    Returns (result, mock_fetch); exceptions from extract_url propagate.
+    """
+    if proxy is None:
+        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
+    else:
+        monkeypatch.setenv("BIBRA_URL_PROXY", proxy)
+
+    kwargs = {}
+    if side_effect is not None:
+        kwargs["side_effect"] = side_effect
+    else:
+        kwargs["return_value"] = MOCK_PDF_BYTES
+
+    with patch("bibra.api.v0.routes.fetch_file", new=AsyncMock(**kwargs)) as mock_fetch:
+        result = await extract_url(
+            project_id="dummy", registry=ProjectRegistry(), url=url
+        )
+    return result, mock_fetch
+
+
+def _mock_request(state):
+    """Build a mock FastAPI Request carrying the given app.state."""
+    mock_app = MagicMock()
+    mock_app.state = state
+    request = MagicMock(spec=Request)
+    request.app = mock_app
+    return request
 
 
 class TestAPIRoutes:
     """Tests for API v0 routes."""
 
-    def test_root_route_exists(self):
-        """The router should have a root route."""
-        assert len(router.routes) >= 1
-
-    def test_projects_route_exists(self):
-        """The router should have a projects route."""
-        routes = [str(r.path) for r in router.routes]
-        assert "/projects" in routes
+    @pytest.mark.parametrize(
+        ("path", "methods"),
+        [
+            ("/", {"GET"}),
+            ("/projects", {"GET"}),
+            ("/projects/{project_id}/extract", {"POST"}),
+            ("/projects/{project_id}/extract-url", {"POST"}),
+        ],
+        ids=["root", "projects", "extract", "extract-url"],
+    )
+    def test_route_exists_with_method(self, path, methods):
+        """Each documented route exists and accepts exactly the expected methods."""
+        matching = [r for r in router.routes if str(r.path) == path]
+        assert len(matching) == 1, f"route {path} not found"
+        route = matching[0]
+        assert isinstance(route, APIRoute)
+        assert route.methods == methods
 
     async def test_list_projects_returns_projects(self):
         """The /projects endpoint should return configured projects."""
-        from bibra.config import ProjectRegistry
-
         registry = ProjectRegistry()
         result = await list_projects(registry=registry)
         assert "projects" in result
@@ -42,139 +108,48 @@ class TestAPIRoutes:
         project_ids = [p["id"] for p in result["projects"]]
         assert "dummy" in project_ids
 
-    def test_extract_route_exists(self):
-        """The router should have a project-specific extract route."""
-        routes = [str(r.path) for r in router.routes]
-        assert "/projects/{project_id}/extract" in routes
-
-    def test_extract_route_is_post_method(self):
-        """The extract route should use POST method."""
-        extract_routes = [
-            r for r in router.routes if str(r.path) == "/projects/{project_id}/extract"
-        ]
-        assert len(extract_routes) >= 1
-        # Check that the route uses POST method
-        route = extract_routes[0]
-        assert isinstance(route, APIRoute)
-
     async def test_extract_returns_example_metadata(self):
         """The /projects/{project_id}/extract endpoint should return example
         publication metadata."""
-        from bibra.config import ProjectRegistry
-
         registry = ProjectRegistry()
         # Use dummy backend for testing (no API calls needed)
         result = await extract(project_id="dummy", files=[], registry=registry)
-
-        assert isinstance(result, PublicationMetadata)
-        assert result.language == "en"
-        assert (
-            result.title == "Machine Learning Approaches for Software Defect Prediction"
-        )
-        assert result.creator == ["Smith, John", "Johnson, Emily"]
-        assert result.year == "2023"
-        assert result.publisher == ["Springer", "ACM"]
-        assert result.doi == "10.1234/example.doi.12345"
-        assert result.e_isbn == ["978-0-123456-78-9"]
-        assert result.type_coar == "article"
-
-        # Verify fields that don't have values are None or empty lists
-        assert result.alt_title is None
-        assert result.p_isbn == []
-        assert result.e_issn is None
-
-    def test_extract_url_route_exists(self):
-        """The router should have a project-specific extract-url route."""
-        routes = [str(r.path) for r in router.routes]
-        assert "/projects/{project_id}/extract-url" in routes
-
-    def test_extract_url_route_is_post_method(self):
-        """The extract-url route should use POST method."""
-        extract_url_routes = [
-            r
-            for r in router.routes
-            if str(r.path) == "/projects/{project_id}/extract-url"
-        ]
-        route = extract_url_routes[0]
-        assert isinstance(route, APIRoute)
-        assert "POST" in route.methods
+        assert_dummy_metadata(result)
 
     async def test_extract_url_returns_example_metadata(self, monkeypatch):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""
-        from pydantic import HttpUrl
-
-        registry = ProjectRegistry()
-        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
-
-        with patch(
-            "bibra.api.v0.routes.fetch_file",
-            new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
-        ) as mock_fetch:
-            result = await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("https://example.com/paper.pdf"),
-            )
+        result, mock_fetch = await _call_extract_url(monkeypatch, "direct", DUMMY_URL)
 
         mock_fetch.assert_awaited_once()
         args, _ = mock_fetch.call_args
         assert args[0] == "https://example.com/paper.pdf"
         assert args[1].proxy == "direct"
 
-        assert isinstance(result, PublicationMetadata)
-        assert result.language == "en"
-        assert (
-            result.title == "Machine Learning Approaches for Software Defect Prediction"
-        )
-        assert result.creator == ["Smith, John", "Johnson, Emily"]
-        assert result.year == "2023"
-        assert result.publisher == ["Springer", "ACM"]
-        assert result.doi == "10.1234/example.doi.12345"
-        assert result.e_isbn == ["978-0-123456-78-9"]
-        assert result.type_coar == "article"
-        # Verify fields that don't have values are None or empty lists
-        assert result.alt_title is None
-        assert result.p_isbn == []
-        assert result.e_issn is None
+        assert_dummy_metadata(result)
 
     def test_get_registry_returns_existing_registry(self):
         """get_registry should return the registry already on app.state."""
-        mock_state = MagicMock()
-        mock_state.project_registry = ProjectRegistry("tests/projects.toml")
-        mock_app = MagicMock()
-        mock_app.state = mock_state
-        request = MagicMock(spec=Request)
-        request.app = mock_app
+        expected = ProjectRegistry("tests/projects.toml")
+        request = _mock_request(MagicMock(project_registry=expected))
 
-        result = get_registry(request)
-        assert result is mock_state.project_registry
+        assert get_registry(request) is expected
 
     def test_get_registry_lazy_initializes_when_missing(self):
         """Lazily create and load a registry when not on app.state."""
-        mock_state = MagicMock(spec=[])  # Empty spec so getattr returns None
-        mock_app = MagicMock()
-        mock_app.state = mock_state
-        request = MagicMock(spec=Request)
-        request.app = mock_app
+        request = _mock_request(MagicMock(spec=[]))  # empty spec: no attrs
 
         result = get_registry(request)
         assert isinstance(result, ProjectRegistry)
         # Verify it was attached back to app.state
-        assert mock_app.state.project_registry is result
+        assert request.app.state.project_registry is result
         # Verify .load() was called (projects populated from tests/projects.toml)
         assert len(result._projects) > 0
 
     def test_get_registry_lazy_load_fails_on_bad_config(self, monkeypatch):
         """get_registry should raise ConfigFileNotFoundError for missing config."""
-        from bibra.config import ConfigFileNotFoundError
-
         monkeypatch.setenv("BIBRA_CONFIG", "nonexistent-path/projects.toml")
-        mock_state = MagicMock(spec=[])
-        mock_app = MagicMock()
-        mock_app.state = mock_state
-        request = MagicMock(spec=Request)
-        request.app = mock_app
+        request = _mock_request(MagicMock(spec=[]))
 
         with pytest.raises(ConfigFileNotFoundError):
             get_registry(request)
@@ -216,130 +191,65 @@ class TestAPIRoutes:
 
     async def test_extract_url_uses_configured_proxy(self, monkeypatch):
         """The fetch policy passed to fetch_file carries the configured proxy."""
-        from pydantic import HttpUrl
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
-
-        registry = ProjectRegistry()
-
-        with patch(
-            "bibra.api.v0.routes.fetch_file",
-            new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
-        ) as mock_fetch:
-            result = await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("https://example.com/paper.pdf"),
-            )
+        _, mock_fetch = await _call_extract_url(
+            monkeypatch, "http://proxy.example.com:8080", DUMMY_URL
+        )
 
         args, _ = mock_fetch.call_args
         assert args[1].proxy == "http://proxy.example.com:8080"
-        assert isinstance(result, PublicationMetadata)
 
     async def test_extract_url_refused_when_proxy_not_set(self, monkeypatch):
         """With no proxy/direct configured the endpoint returns 503."""
-        from pydantic import HttpUrl
-
-        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
-
-        registry = ProjectRegistry()
-
-        with (
-            patch(
-                "bibra.api.v0.routes.fetch_file",
-                new=AsyncMock(
-                    side_effect=ProxyRequiredError(ProxyRequiredError.MESSAGE)
-                ),
-            ) as mock_fetch,
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("https://example.com/paper.pdf"),
+        with pytest.raises(HTTPException) as exc_info:
+            await _call_extract_url(
+                monkeypatch,
+                None,
+                DUMMY_URL,
+                side_effect=ProxyRequiredError(ProxyRequiredError.MESSAGE),
             )
 
-        mock_fetch.assert_awaited_once()
         assert exc_info.value.status_code == 503
         assert "BIBRA_URL_PROXY" in exc_info.value.detail
 
     async def test_extract_url_policy_error_returns_400(self, monkeypatch):
         """A URL rejected by the fetch policy returns 400 with a generic detail."""
-        from pydantic import HttpUrl
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
-
-        registry = ProjectRegistry()
-
-        with (
-            patch(
-                "bibra.api.v0.routes.fetch_file",
-                new=AsyncMock(
-                    side_effect=UrlPolicyError("URL rejected by fetch policy")
-                ),
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("http://169.254.169.254/latest/meta-data/"),
+        with pytest.raises(HTTPException) as exc_info:
+            await _call_extract_url(
+                monkeypatch,
+                "direct",
+                HttpUrl("http://169.254.169.254/latest/meta-data/"),
+                side_effect=UrlPolicyError("URL rejected by fetch policy"),
             )
 
         assert exc_info.value.status_code == 400
         assert "169.254.169.254" not in exc_info.value.detail
 
-    async def test_extract_url_dns_failure_returns_502(self, monkeypatch):
-        """A hostname that does not resolve returns 502, not a 400 policy rejection."""
-        from pydantic import HttpUrl
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
-
-        registry = ProjectRegistry()
-
-        with (
-            patch(
-                "bibra.api.v0.routes.fetch_file",
-                new=AsyncMock(
-                    side_effect=httpx2.ConnectError("Could not resolve host")
-                ),
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("https://nonexistent-host.invalid/paper.pdf"),
+    @pytest.mark.parametrize(
+        ("side_effect", "leaked_detail"),
+        [
+            (
+                httpx2.ConnectError("Could not resolve host"),
+                "nonexistent-host",
+            ),  # DNS failure
+            (
+                httpx2.HTTPError("connection refused to internal host"),
+                "internal",
+            ),  # failed download
+        ],
+        ids=["dns-failure-502", "http-error-502"],
+    )
+    async def test_extract_url_download_failure_returns_502(
+        self, monkeypatch, side_effect, leaked_detail
+    ):
+        """A failed download returns 502 without leaking internal details."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _call_extract_url(
+                monkeypatch, "direct", DUMMY_URL, side_effect=side_effect
             )
 
         assert exc_info.value.status_code == 502
         assert exc_info.value.detail == "Failed to download URL"
-
-    async def test_extract_url_http_error_returns_502(self, monkeypatch):
-        """A failed download returns 502 without leaking internal details."""
-        from pydantic import HttpUrl
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
-
-        registry = ProjectRegistry()
-
-        with (
-            patch(
-                "bibra.api.v0.routes.fetch_file",
-                new=AsyncMock(
-                    side_effect=httpx2.HTTPError("connection refused to internal host")
-                ),
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await extract_url(
-                project_id="dummy",
-                registry=registry,
-                url=HttpUrl("https://example.com/paper.pdf"),
-            )
-
-        assert exc_info.value.status_code == 502
-        assert "internal" not in exc_info.value.detail
+        assert leaked_detail not in exc_info.value.detail
 
     @pytest.mark.parametrize(
         ("side_effect",),
@@ -358,11 +268,7 @@ class TestAPIRoutes:
         A caller can plant credentials or tokens in the URL; every log
         record from the endpoint's failure paths must be free of them.
         """
-        from pydantic import HttpUrl
-
         monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
-
-        registry = ProjectRegistry()
         url = HttpUrl(
             "https://user:supersecrettoken@api.example.com/doc.pdf?key=abc123"
         )
@@ -374,7 +280,7 @@ class TestAPIRoutes:
             caplog.at_level("INFO"),
             pytest.raises(HTTPException),
         ):
-            await extract_url(project_id="dummy", registry=registry, url=url)
+            await extract_url(project_id="dummy", registry=ProjectRegistry(), url=url)
 
         assert "supersecrettoken" not in caplog.text
         assert "key=abc123" not in caplog.text
@@ -382,10 +288,6 @@ class TestAPIRoutes:
 
     async def test_extract_url_cleanup_temp_file_on_backend_error(self, monkeypatch):
         """The temporary file is removed even if the backend raises."""
-        from pydantic import HttpUrl
-
-        from bibra.backend.base import BaseBackend
-
         monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
 
         registry = ProjectRegistry()
@@ -400,7 +302,7 @@ class TestAPIRoutes:
         with (
             patch(
                 "bibra.api.v0.routes.fetch_file",
-                new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
+                new=AsyncMock(return_value=MOCK_PDF_BYTES),
             ),
             patch("bibra.backend.base.os.unlink") as mock_unlink,
             pytest.raises(RuntimeError, match="boom"),
@@ -408,7 +310,7 @@ class TestAPIRoutes:
             await extract_url(
                 project_id="dummy",
                 registry=registry,
-                url=HttpUrl("https://example.com/paper.pdf"),
+                url=DUMMY_URL,
             )
 
         mock_unlink.assert_called_once()

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
-from httpx import Headers
+from httpx2 import Headers
 
 from bibra.api.v0.routes import (
     extract,
@@ -114,7 +114,7 @@ class TestAPIRoutes:
         mock_response.status_code = 200
         mock_response.aiter_bytes.return_value = mock_aiter_bytes()
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        with patch("httpx2.AsyncClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -219,7 +219,7 @@ class TestAPIRoutes:
         assert exc_info.value.detail == "Project 'unknown' not found"
 
     async def test_extract_url_passes_proxy_when_set(self, monkeypatch):
-        """Test that extract-url passes the proxy to httpx.AsyncClient when set."""
+        """Test that extract-url passes the proxy to httpx2.AsyncClient when set."""
         from pydantic import HttpUrl
 
         monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
@@ -234,7 +234,7 @@ class TestAPIRoutes:
         mock_response.status_code = 200
         mock_response.aiter_bytes.return_value = mock_aiter_bytes()
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        with patch("httpx2.AsyncClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -265,7 +265,7 @@ class TestAPIRoutes:
         mock_response.status_code = 200
         mock_response.aiter_bytes.return_value = mock_aiter_bytes()
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        with patch("httpx2.AsyncClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -94,11 +94,9 @@ class TestAPIRoutes:
             for r in router.routes
             if str(r.path) == "/projects/{project_id}/extract-url"
         ]
-        assert len(extract_url_routes) >= 1
-        # Check that the route uses POST method
         route = extract_url_routes[0]
         assert isinstance(route, APIRoute)
-
+        assert "POST" in route.methods
     async def test_extract_url_returns_example_metadata(self):
         """The /projects/{project_id}/extract-url endpoint should return example
         publication metadata."""

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -18,6 +18,33 @@ from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
 from bibra.types import PublicationMetadata
 
 
+def _make_stream_client_mock():
+    """Build a mock httpx2.AsyncClient matching extract_url()'s streaming usage.
+
+    The mock supports ``async with client as c: async with c.stream(...) as r``
+    and yields a single PDF-like byte chunk from ``r.aiter_bytes()``.
+    """
+
+    async def mock_aiter_bytes(*args, **kwargs):
+        yield b"%PDF-1.4 mock content"
+
+    mock_response = MagicMock()
+    mock_response.headers = Headers({"content-type": "application/pdf"})
+    mock_response.status_code = 200
+    mock_response.reason_phrase = "OK"
+    mock_response.aiter_bytes.return_value = mock_aiter_bytes()
+
+    mock_stream_cm = MagicMock()
+    mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.stream.return_value = mock_stream_cm
+    return mock_client
+
+
 class TestAPIRoutes:
     """Tests for API v0 routes."""
 
@@ -105,19 +132,8 @@ class TestAPIRoutes:
 
         registry = ProjectRegistry()
 
-        async def mock_aiter_bytes(*args, **kwargs):
-            yield b"%PDF-1.4 mock content"
-
-        mock_response = MagicMock()
-        mock_response.headers = Headers({"content-type": "application/pdf"})
-        mock_response.status_code = 200
-        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-
         with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client = _make_stream_client_mock()
             mock_client_cls.return_value = mock_client
             result = await extract_url(
                 project_id="dummy",
@@ -225,19 +241,8 @@ class TestAPIRoutes:
 
         registry = ProjectRegistry()
 
-        async def mock_aiter_bytes(*args, **kwargs):
-            yield b"%PDF-1.4 mock content"
-
-        mock_response = MagicMock()
-        mock_response.headers = Headers({"content-type": "application/pdf"})
-        mock_response.status_code = 200
-        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-
         with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client = _make_stream_client_mock()
             mock_client_cls.return_value = mock_client
             result = await extract_url(
                 project_id="dummy",
@@ -256,19 +261,8 @@ class TestAPIRoutes:
 
         registry = ProjectRegistry()
 
-        async def mock_aiter_bytes(*args, **kwargs):
-            yield b"%PDF-1.4 mock content"
-
-        mock_response = MagicMock()
-        mock_response.headers = Headers({"content-type": "application/pdf"})
-        mock_response.status_code = 200
-        mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-
         with patch("httpx2.AsyncClient") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client = _make_stream_client_mock()
             mock_client_cls.return_value = mock_client
             result = await extract_url(
                 project_id="dummy",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -341,6 +341,45 @@ class TestAPIRoutes:
         assert exc_info.value.status_code == 502
         assert "internal" not in exc_info.value.detail
 
+    @pytest.mark.parametrize(
+        ("side_effect",),
+        [
+            (ProxyRequiredError(ProxyRequiredError.MESSAGE),),
+            (UrlPolicyError("URL rejected by fetch policy"),),
+            (httpx2.HTTPError("connection refused"),),
+        ],
+        ids=["proxy-required-503", "policy-error-400", "http-error-502"],
+    )
+    async def test_extract_url_error_logs_redacted_url(
+        self, monkeypatch, caplog, side_effect
+    ):
+        """Error handlers never log userinfo/query of the submitted URL.
+
+        A caller can plant credentials or tokens in the URL; every log
+        record from the endpoint's failure paths must be free of them.
+        """
+        from pydantic import HttpUrl
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        registry = ProjectRegistry()
+        url = HttpUrl(
+            "https://user:supersecrettoken@api.example.com/doc.pdf?key=abc123"
+        )
+
+        with (
+            patch(
+                "bibra.api.v0.routes.fetch_file", new=AsyncMock(side_effect=side_effect)
+            ),
+            caplog.at_level("INFO"),
+            pytest.raises(HTTPException),
+        ):
+            await extract_url(project_id="dummy", registry=registry, url=url)
+
+        assert "supersecrettoken" not in caplog.text
+        assert "key=abc123" not in caplog.text
+        assert "api.example.com/doc.pdf" in caplog.text
+
     async def test_extract_url_cleanup_temp_file_on_backend_error(self, monkeypatch):
         """The temporary file is removed even if the backend raises."""
         from pydantic import HttpUrl

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -22,7 +22,12 @@ from bibra.config import (
     ProjectNotFoundError,
     ProjectRegistry,
 )
-from bibra.net_security import ProxyRequiredError, UrlPolicyError
+from bibra.net_security import (
+    DownloadSizeExceededError,
+    ProxyRequiredError,
+    UnsupportedContentTypeError,
+    UrlPolicyError,
+)
 from bibra.types import PublicationMetadata
 
 MOCK_PDF_BYTES = b"%PDF-1.4 mock content"
@@ -222,7 +227,40 @@ class TestAPIRoutes:
             )
 
         assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "URL rejected by fetch policy"
         assert "169.254.169.254" not in exc_info.value.detail
+
+    async def test_extract_url_download_size_exceeded_returns_400(self, monkeypatch):
+        """An oversized download returns 400 with a specific size detail."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _call_extract_url(
+                monkeypatch,
+                "direct",
+                DUMMY_URL,
+                side_effect=DownloadSizeExceededError(
+                    DownloadSizeExceededError.MESSAGE
+                ),
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == DownloadSizeExceededError.MESSAGE
+        assert exc_info.value.detail != "URL rejected by fetch policy"
+
+    async def test_extract_url_unsupported_type_returns_400(self, monkeypatch):
+        """A non-PDF download returns 400 with a specific file-type detail."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _call_extract_url(
+                monkeypatch,
+                "direct",
+                DUMMY_URL,
+                side_effect=UnsupportedContentTypeError(
+                    UnsupportedContentTypeError.MESSAGE
+                ),
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == UnsupportedContentTypeError.MESSAGE
+        assert exc_info.value.detail != "URL rejected by fetch policy"
 
     @pytest.mark.parametrize(
         ("side_effect", "leaked_detail"),
@@ -256,9 +294,17 @@ class TestAPIRoutes:
         [
             (ProxyRequiredError(ProxyRequiredError.MESSAGE),),
             (UrlPolicyError("URL rejected by fetch policy"),),
+            (DownloadSizeExceededError(DownloadSizeExceededError.MESSAGE),),
+            (UnsupportedContentTypeError(UnsupportedContentTypeError.MESSAGE),),
             (httpx2.HTTPError("connection refused"),),
         ],
-        ids=["proxy-required-503", "policy-error-400", "http-error-502"],
+        ids=[
+            "proxy-required-503",
+            "policy-error-400",
+            "size-exceeded-400",
+            "unsupported-type-400",
+            "http-error-502",
+        ],
     )
     async def test_extract_url_error_logs_redacted_url(
         self, monkeypatch, caplog, side_effect

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -1,0 +1,74 @@
+"""Tests for the BaseBackend.extract_from_bytes helper."""
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bibra.backend.base import BaseBackend
+from bibra.types import PublicationMetadata
+
+
+class _ConcreteBackend(BaseBackend):
+    """Minimal concrete backend for exercising the shared helper.
+
+    Records the file paths it is given so tests can assert the temp file
+    held the right bytes and was removed afterwards.
+    """
+
+    def __init__(self, holder: list[str], expected: bytes | None = None):
+        self._holder = holder
+        self._expected = expected
+
+    async def extract(self, file_paths: list[str]) -> PublicationMetadata:
+        self._holder.extend(file_paths)
+        # Verify the temp file held exactly the bytes the helper wrote.
+        # (to_thread keeps the async method free of blocking I/O.)
+        if self._expected is not None:
+            for path in file_paths:
+                contents = await asyncio.to_thread(Path(path).read_bytes)
+                if contents != self._expected:
+                    raise AssertionError("temp file contents mismatch")
+        return PublicationMetadata()
+
+    @classmethod
+    def build_config(cls, project) -> dict:
+        return {}
+
+
+def test_writes_bytes_and_cleans_up():
+    """The temp file is created with the exact bytes and removed after."""
+    holder: list[str] = []
+    backend = _ConcreteBackend(holder, expected=b"%PDF-1.4 test")
+
+    with patch("bibra.backend.base.os.unlink") as mock_unlink:
+        result = asyncio.run(backend.extract_from_bytes(b"%PDF-1.4 test"))
+
+    assert isinstance(result, PublicationMetadata)
+    # extract() was called with exactly one temp file path.
+    assert len(holder) == 1
+    (tmp_path,) = holder
+    assert tmp_path.endswith(".pdf")
+    # The helper removed the temp file.
+    mock_unlink.assert_called_once_with(tmp_path)
+
+
+def test_temp_file_removed_even_on_error():
+    """The temp file is removed even when extract() raises."""
+
+    class FailingBackend(_ConcreteBackend):
+        async def extract(self, file_paths: list[str]) -> PublicationMetadata:
+            self._holder.extend(file_paths)
+            raise RuntimeError("boom")
+
+    holder: list[str] = []
+    backend = FailingBackend(holder)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(backend.extract_from_bytes(b"%PDF-1.4 test"))
+
+    assert len(holder) == 1
+    # The real unlink runs (no patch): the file is gone from disk.
+    assert not os.path.exists(holder[0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,16 +250,15 @@ class TestExtract:
 """Tests for the extract-url command."""
 
 
-def _make_urlopen_mock(chunks=(b"%PDF-1.4 dummy content", b"")):
-    """Build a mock for urllib.request.urlopen that yields the given chunks
-    from .read() and supports use as a context manager."""
+def _make_httpx_stream_mock(chunks=(b"%PDF-1.4 dummy content",)):
+    """Build a mock for httpx stream response that yields the given chunks."""
     mock_response = MagicMock()
-    mock_response.read.side_effect = list(chunks)
-
-    mock_cm = MagicMock()
-    mock_cm.__enter__.return_value = mock_response
-    mock_cm.__exit__.return_value = False
-    return mock_cm
+    mock_response.headers.get.return_value = "application/pdf"
+    mock_response.status_code = 200
+    mock_response.iter_bytes.return_value = chunks
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+    return mock_response
 
 
 def _make_backend(json_payload=None):
@@ -309,12 +308,12 @@ class TestExtractUrl:
         """Test extract-url command with a valid URL and successful extraction."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]
@@ -333,12 +332,12 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -365,12 +364,12 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -400,7 +399,7 @@ class TestExtractUrl:
         assert "not found" in result.output
 
     def test_extract_url_config_error_converted_to_click_exception(self):
-        """Test that ConfigError while resolving the backend becomes a ClickException."""
+        """Test ConfigError during backend resolution becomes ClickException."""
         with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -414,15 +413,17 @@ class TestExtractUrl:
         assert "Invalid config syntax" in result.output
 
     def test_extract_url_download_failure_converted_to_click_exception(self):
-        """Test that a failure while downloading the URL is wrapped as 'Extraction failed:'."""
+        """Test download failure is wrapped as 'Extraction failed:'."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
+            import httpx as _httpx
+
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.side_effect = OSError("Name or service not known")
+            mock_stream.side_effect = _httpx.HTTPError("Name or service not known")
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://bad.example.invalid/paper.pdf"]
@@ -436,7 +437,7 @@ class TestExtractUrl:
         ClickException with the 'Extraction failed:' prefix."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -447,7 +448,7 @@ class TestExtractUrl:
 
             mock_backend.extract.side_effect = _extract
             mock_registry.get_backend.return_value = mock_backend
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -457,6 +457,53 @@ class TestExtractUrl:
         assert result.exit_code != 0
         assert "Extraction failed: PDF corrupted" in result.output
 
+    def test_extract_url_passes_proxy_when_set(self):
+        """Test that extract-url passes the proxy to httpx.stream when set."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.httpx.stream") as mock_stream,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_stream.return_value = _make_httpx_stream_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf"],
+                env={"BIBRA_URL_PROXY": "http://proxy.example.com:8080"},
+            )
+
+        assert result.exit_code == 0
+        mock_stream.assert_called_once_with(
+            "GET",
+            "https://example.com/paper.pdf",
+            proxy="http://proxy.example.com:8080",
+        )
+
+    def test_extract_url_no_proxy_when_not_set(self):
+        """Test that extract-url passes proxy=None when env var is not set."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.httpx.stream") as mock_stream,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_stream.return_value = _make_httpx_stream_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf"],
+            )
+
+        assert result.exit_code == 0
+        mock_stream.assert_called_once_with(
+            "GET",
+            "https://example.com/paper.pdf",
+            proxy=None,
+        )
+
 
 class TestMakeListTemplate:
     """Tests for the _make_list_template helper function."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from bibra.cli import _make_list_template, cli, extract, list_projects
-from bibra.config import ConfigError
+from bibra.cli import _make_list_template, cli, extract, extract_url, list_projects
+from bibra.config import ConfigError, ProjectNotFoundError
 
 
 class TestCli:
@@ -245,6 +245,216 @@ class TestExtract:
             result = self.runner.invoke(extract, ["dummy", str(test_file)])
             assert result.exit_code != 0
             assert "Invalid config syntax" in result.output
+
+
+"""Tests for the extract-url command."""
+
+
+def _make_urlopen_mock(chunks=(b"%PDF-1.4 dummy content", b"")):
+    """Build a mock for urllib.request.urlopen that yields the given chunks
+    from .read() and supports use as a context manager."""
+    mock_response = MagicMock()
+    mock_response.read.side_effect = list(chunks)
+
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_response
+    mock_cm.__exit__.return_value = False
+    return mock_cm
+
+
+def _make_backend(json_payload=None):
+    """Build a mock backend whose .extract() returns an object with a
+    model_dump_json method, matching what asyncio.run(backend.extract(...))
+    is expected to produce."""
+    if json_payload is None:
+        json_payload = {"title": "Some Paper", "authors": ["A. Author"]}
+
+    mock_result = MagicMock()
+    mock_result.model_dump_json.return_value = json.dumps(json_payload, indent=2)
+
+    mock_backend = MagicMock()
+
+    async def _extract(*args, **kwargs):
+        return mock_result
+
+    mock_backend.extract.side_effect = _extract
+    return mock_backend
+
+
+class TestExtractUrl:
+    """Tests for the extract-url command."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+
+    def test_extract_url_help(self):
+        """Test extract-url help output."""
+        result = self.runner.invoke(extract_url, ["--help"])
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Extract publication metadata" in result.output
+        assert "PROJECT_ID" in result.output
+        assert "URL" in result.output
+        assert "--output" in result.output
+        assert "-o" in result.output
+
+    def test_extract_url_missing_url(self):
+        """Test extract-url command with only a project id (missing URL)."""
+        result = self.runner.invoke(extract_url, ["test-project"])
+        assert result.exit_code != 0
+        assert result.exception
+
+    def test_extract_url_with_valid_url(self):
+        """Test extract-url command with a valid URL and successful extraction."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+
+        output = result.output.strip()
+        data = json.loads(output)
+        assert "title" in data or "authors" in data
+
+    def test_extract_url_with_output_option(self, tmp_path):
+        """Test extract-url command with --output option to write JSON to file."""
+        output_file = tmp_path / "output.json"
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                [
+                    "dummy",
+                    "https://example.com/paper.pdf",
+                    "--output",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Output written to" in result.output
+
+        assert output_file.exists()
+        content = output_file.read_text(encoding="utf-8")
+        data = json.loads(content.strip())
+        assert data is not None
+
+    def test_extract_url_with_short_output_option(self, tmp_path):
+        """Test extract-url command with -o short option."""
+        output_file = tmp_path / "output.json"
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf", "-o", str(output_file)],
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Output written to" in result.output
+
+    def test_extract_url_with_nonexistent_project(self):
+        """Test extract-url command with a project that isn't found."""
+        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.side_effect = ProjectNotFoundError(
+                "Project 'nonexistent-project' not found"
+            )
+
+            result = self.runner.invoke(
+                extract_url,
+                ["nonexistent-project", "https://example.com/paper.pdf"],
+            )
+
+        assert result.exit_code != 0
+        assert result.exception
+        assert "not found" in result.output
+
+    def test_extract_url_config_error_converted_to_click_exception(self):
+        """Test that ConfigError while resolving the backend becomes a ClickException."""
+        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.side_effect = ConfigError("Invalid config syntax")
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Invalid config syntax" in result.output
+
+    def test_extract_url_download_failure_converted_to_click_exception(self):
+        """Test that a failure while downloading the URL is wrapped as 'Extraction failed:'."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.side_effect = OSError("Name or service not known")
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://bad.example.invalid/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Extraction failed:" in result.output
+
+    def test_extract_url_generic_exception_converted_to_click_exception(self):
+        """Test that a generic Exception during extraction is wrapped in
+        ClickException with the 'Extraction failed:' prefix."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_backend = MagicMock()
+
+            async def _extract(*args, **kwargs):
+                raise RuntimeError("PDF corrupted")
+
+            mock_backend.extract.side_effect = _extract
+            mock_registry.get_backend.return_value = mock_backend
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Extraction failed: PDF corrupted" in result.output
 
 
 class TestMakeListTemplate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,12 +321,19 @@ def _make_backend(json_payload=None):
     mock_result = MagicMock()
     mock_result.model_dump_json.return_value = json.dumps(json_payload, indent=2)
 
+    from bibra.backend.base import BaseBackend
+
     mock_backend = MagicMock()
 
     async def _extract(*args, **kwargs):
         return mock_result
 
     mock_backend.extract.side_effect = _extract
+    # Bind the real helper so the temp-file write/cleanup runs (the CLI now
+    # calls extract_from_bytes, not extract).
+    mock_backend.extract_from_bytes = BaseBackend.extract_from_bytes.__get__(
+        mock_backend, type(mock_backend)
+    )
     return mock_backend
 
 
@@ -484,9 +491,12 @@ class TestExtractUrl:
     def test_extract_url_generic_exception_converted_to_click_exception(self):
         """Test that a generic Exception during extraction is wrapped in
         ClickException with the 'Extraction failed:' prefix."""
+        from bibra.backend.base import BaseBackend
+
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
+            patch("bibra.backend.base.os.unlink"),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -496,6 +506,9 @@ class TestExtractUrl:
                 raise RuntimeError("PDF corrupted")
 
             mock_backend.extract.side_effect = _extract
+            mock_backend.extract_from_bytes = BaseBackend.extract_from_bytes.__get__(
+                mock_backend, type(mock_backend)
+            )
             mock_registry.get_backend.return_value = mock_backend
 
             result = self.runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import sys
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -368,7 +368,7 @@ class TestExtractUrl:
         """Test extract-url command with a valid URL and successful extraction."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
+            patch("bibra.cli.fetch_file", new=AsyncMock(return_value=MOCK_PDF_BYTES)),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -391,7 +391,7 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
+            patch("bibra.cli.fetch_file", new=AsyncMock(return_value=MOCK_PDF_BYTES)),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -422,7 +422,7 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
+            patch("bibra.cli.fetch_file", new=AsyncMock(return_value=MOCK_PDF_BYTES)),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -476,8 +476,10 @@ class TestExtractUrl:
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch(
-                "bibra.cli.fetch_file_sync",
-                side_effect=_httpx.HTTPError("Name or service not known"),
+                "bibra.cli.fetch_file",
+                new=AsyncMock(
+                    side_effect=_httpx.HTTPError("Name or service not known")
+                ),
             ),
         ):
             mock_registry = MagicMock()
@@ -498,7 +500,7 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
+            patch("bibra.cli.fetch_file", new=AsyncMock(return_value=MOCK_PDF_BYTES)),
             patch("bibra.backend.base.os.unlink"),
         ):
             mock_registry = MagicMock()
@@ -522,11 +524,11 @@ class TestExtractUrl:
         assert "Extraction failed: PDF corrupted" in result.output
 
     def test_extract_url_uses_configured_proxy(self):
-        """Test that the fetch policy passed to fetch_file_sync carries the proxy."""
+        """Test that the fetch policy passed to fetch_file carries the proxy."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch(
-                "bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES
+                "bibra.cli.fetch_file", new=AsyncMock(return_value=MOCK_PDF_BYTES)
             ) as mock_fetch,
         ):
             mock_registry = MagicMock()
@@ -552,8 +554,8 @@ class TestExtractUrl:
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch(
-                "bibra.cli.fetch_file_sync",
-                return_value=MOCK_PDF_BYTES,
+                "bibra.cli.fetch_file",
+                new=AsyncMock(return_value=MOCK_PDF_BYTES),
             ) as mock_fetch,
         ):
             mock_registry = MagicMock()
@@ -577,8 +579,8 @@ class TestExtractUrl:
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch(
-                "bibra.cli.fetch_file_sync",
-                return_value=MOCK_PDF_BYTES,
+                "bibra.cli.fetch_file",
+                new=AsyncMock(return_value=MOCK_PDF_BYTES),
             ) as mock_fetch,
         ):
             mock_registry = MagicMock()
@@ -601,8 +603,10 @@ class TestExtractUrl:
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch(
-                "bibra.cli.fetch_file_sync",
-                side_effect=UrlPolicyError("URL rejected by fetch policy"),
+                "bibra.cli.fetch_file",
+                new=AsyncMock(
+                    side_effect=UrlPolicyError("URL rejected by fetch policy")
+                ),
             ),
         ):
             mock_registry = MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,16 +306,15 @@ class TestServe:
             )
 
 
-def _make_urlopen_mock(chunks=(b"%PDF-1.4 dummy content", b"")):
-    """Build a mock for urllib.request.urlopen that yields the given chunks
-    from .read() and supports use as a context manager."""
+def _make_httpx_stream_mock(chunks=(b"%PDF-1.4 dummy content",)):
+    """Build a mock for httpx stream response that yields the given chunks."""
     mock_response = MagicMock()
-    mock_response.read.side_effect = list(chunks)
-
-    mock_cm = MagicMock()
-    mock_cm.__enter__.return_value = mock_response
-    mock_cm.__exit__.return_value = False
-    return mock_cm
+    mock_response.headers.get.return_value = "application/pdf"
+    mock_response.status_code = 200
+    mock_response.iter_bytes.return_value = chunks
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+    return mock_response
 
 
 def _make_backend(json_payload=None):
@@ -365,12 +364,12 @@ class TestExtractUrl:
         """Test extract-url command with a valid URL and successful extraction."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]
@@ -389,12 +388,12 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -421,12 +420,12 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -456,7 +455,7 @@ class TestExtractUrl:
         assert "not found" in result.output
 
     def test_extract_url_config_error_converted_to_click_exception(self):
-        """Test that ConfigError while resolving the backend becomes a ClickException."""
+        """Test ConfigError during backend resolution becomes ClickException."""
         with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -470,15 +469,17 @@ class TestExtractUrl:
         assert "Invalid config syntax" in result.output
 
     def test_extract_url_download_failure_converted_to_click_exception(self):
-        """Test that a failure while downloading the URL is wrapped as 'Extraction failed:'."""
+        """Test download failure is wrapped as 'Extraction failed:'."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
+            import httpx as _httpx
+
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_urlopen.side_effect = OSError("Name or service not known")
+            mock_stream.side_effect = _httpx.HTTPError("Name or service not known")
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://bad.example.invalid/paper.pdf"]
@@ -492,7 +493,7 @@ class TestExtractUrl:
         ClickException with the 'Extraction failed:' prefix."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+            patch("bibra.cli.httpx.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -503,7 +504,7 @@ class TestExtractUrl:
 
             mock_backend.extract.side_effect = _extract
             mock_registry.get_backend.return_value = mock_backend
-            mock_urlopen.return_value = _make_urlopen_mock()
+            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -528,12 +528,18 @@ class TestExtractUrl:
         assert args[0] == "https://example.com/paper.pdf"
         assert args[1].proxy == "http://proxy.example.com:8080"
 
-    def test_extract_url_refused_when_proxy_not_set(self, monkeypatch):
-        """Without BIBRA_URL_PROXY, the real fetch path refuses before any
-        network I/O and the command reports that URL fetching is disabled."""
+    def test_extract_url_falls_back_to_direct_when_proxy_not_set(self, monkeypatch):
+        """Unlike the API, the CLI is lenient: with BIBRA_URL_PROXY unset it
+        behaves as if it were "direct" (full validation still applies)."""
         monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
 
-        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch(
+                "bibra.cli.fetch_file_sync",
+                return_value=MOCK_PDF_BYTES,
+            ) as mock_fetch,
+        ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
@@ -543,8 +549,34 @@ class TestExtractUrl:
                 ["dummy", "https://example.com/paper.pdf"],
             )
 
-        assert result.exit_code != 0
-        assert "BIBRA_URL_PROXY" in result.output
+        assert result.exit_code == 0
+        args, _ = mock_fetch.call_args
+        assert args[0] == "https://example.com/paper.pdf"
+        assert args[1].proxy == "direct"
+
+    def test_extract_url_proxy_not_overridden_when_set(self, monkeypatch):
+        """An explicitly configured proxy URL is used as-is by the CLI."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch(
+                "bibra.cli.fetch_file_sync",
+                return_value=MOCK_PDF_BYTES,
+            ) as mock_fetch,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf"],
+            )
+
+        assert result.exit_code == 0
+        args, _ = mock_fetch.call_args
+        assert args[1].proxy == "http://proxy.example.com:8080"
 
     def test_extract_url_policy_error_converted_to_click_exception(self):
         """A URL rejected by the fetch policy becomes a ClickException."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,7 +467,7 @@ class TestExtractUrl:
         assert "Invalid config syntax" in result.output
 
     def test_extract_url_download_failure_converted_to_click_exception(self):
-        """Test download failure is wrapped as 'Extraction failed:'."""
+        """Test download failure is wrapped as 'Extraction failed (network):'."""
         import httpx2 as _httpx
 
         with (
@@ -486,7 +486,7 @@ class TestExtractUrl:
             )
 
         assert result.exit_code != 0
-        assert "Extraction failed:" in result.output
+        assert "Extraction failed (network):" in result.output
 
     def test_extract_url_generic_exception_converted_to_click_exception(self):
         """Test that a generic Exception during extraction is wrapped in
@@ -612,7 +612,8 @@ class TestExtractUrl:
             )
 
         assert result.exit_code != 0
-        assert "Extraction failed: URL rejected by fetch policy" in result.output
+        assert "Extraction failed (policy):" in result.output
+        assert "URL rejected by fetch policy" in result.output
         assert "169.254.169.254" not in result.output
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,16 +308,7 @@ class TestServe:
 
 # Tests for the extract-url command.
 
-
-def _make_httpx_stream_mock(chunks=(b"%PDF-1.4 dummy content",)):
-    """Build a mock for httpx2 stream response that yields the given chunks."""
-    mock_response = MagicMock()
-    mock_response.headers.get.return_value = "application/pdf"
-    mock_response.status_code = 200
-    mock_response.iter_bytes.return_value = chunks
-    mock_response.__enter__.return_value = mock_response
-    mock_response.__exit__.return_value = False
-    return mock_response
+MOCK_PDF_BYTES = b"%PDF-1.4 dummy content"
 
 
 def _make_backend(json_payload=None):
@@ -367,12 +358,11 @@ class TestExtractUrl:
         """Test extract-url command with a valid URL and successful extraction."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]
@@ -391,12 +381,11 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -423,12 +412,11 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -473,16 +461,18 @@ class TestExtractUrl:
 
     def test_extract_url_download_failure_converted_to_click_exception(self):
         """Test download failure is wrapped as 'Extraction failed:'."""
+        import httpx2 as _httpx
+
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch(
+                "bibra.cli.fetch_file_sync",
+                side_effect=_httpx.HTTPError("Name or service not known"),
+            ),
         ):
-            import httpx2 as _httpx
-
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.side_effect = _httpx.HTTPError("Name or service not known")
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://bad.example.invalid/paper.pdf"]
@@ -496,7 +486,7 @@ class TestExtractUrl:
         ClickException with the 'Extraction failed:' prefix."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch("bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -507,7 +497,6 @@ class TestExtractUrl:
 
             mock_backend.extract.side_effect = _extract
             mock_registry.get_backend.return_value = mock_backend
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url, ["dummy", "https://example.com/paper.pdf"]
@@ -516,16 +505,17 @@ class TestExtractUrl:
         assert result.exit_code != 0
         assert "Extraction failed: PDF corrupted" in result.output
 
-    def test_extract_url_passes_proxy_when_set(self):
-        """Test that extract-url passes the proxy to httpx2.stream when set."""
+    def test_extract_url_uses_configured_proxy(self):
+        """Test that the fetch policy passed to fetch_file_sync carries the proxy."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch(
+                "bibra.cli.fetch_file_sync", return_value=MOCK_PDF_BYTES
+            ) as mock_fetch,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
@@ -534,35 +524,51 @@ class TestExtractUrl:
             )
 
         assert result.exit_code == 0
-        mock_stream.assert_called_once_with(
-            "GET",
-            "https://example.com/paper.pdf",
-            proxy="http://proxy.example.com:8080",
-        )
+        args, _ = mock_fetch.call_args
+        assert args[0] == "https://example.com/paper.pdf"
+        assert args[1].proxy == "http://proxy.example.com:8080"
 
-    def test_extract_url_no_proxy_when_not_set(self):
-        """Test that extract-url passes proxy=None when env var is not set."""
-        with (
-            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx2.stream") as mock_stream,
-            patch("bibra.cli.get_url_proxy", return_value=None),
-        ):
+    def test_extract_url_refused_when_proxy_not_set(self, monkeypatch):
+        """Without BIBRA_URL_PROXY, the real fetch path refuses before any
+        network I/O and the command reports that URL fetching is disabled."""
+        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
+
+        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
             mock_registry.get_backend.return_value = _make_backend()
-            mock_stream.return_value = _make_httpx_stream_mock()
 
             result = self.runner.invoke(
                 extract_url,
                 ["dummy", "https://example.com/paper.pdf"],
             )
 
-        assert result.exit_code == 0
-        mock_stream.assert_called_once_with(
-            "GET",
-            "https://example.com/paper.pdf",
-            proxy=None,
-        )
+        assert result.exit_code != 0
+        assert "BIBRA_URL_PROXY" in result.output
+
+    def test_extract_url_policy_error_converted_to_click_exception(self):
+        """A URL rejected by the fetch policy becomes a ClickException."""
+        from bibra.net_security import UrlPolicyError
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch(
+                "bibra.cli.fetch_file_sync",
+                side_effect=UrlPolicyError("URL rejected by fetch policy"),
+            ),
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "http://169.254.169.254/latest/meta-data/"],
+            )
+
+        assert result.exit_code != 0
+        assert "Extraction failed: URL rejected by fetch policy" in result.output
+        assert "169.254.169.254" not in result.output
 
 
 class TestMakeListTemplate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -304,6 +304,7 @@ class TestServe:
             mock_uvicorn_run.assert_called_once_with(
                 "bibra.main:app", host="127.0.0.1", port=9999, reload=False
             )
+# Tests for the extract-url command.
 
 
 def _make_httpx_stream_mock(chunks=(b"%PDF-1.4 dummy content",)):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,6 +513,53 @@ class TestExtractUrl:
         assert result.exit_code != 0
         assert "Extraction failed: PDF corrupted" in result.output
 
+    def test_extract_url_passes_proxy_when_set(self):
+        """Test that extract-url passes the proxy to httpx.stream when set."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.httpx.stream") as mock_stream,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_stream.return_value = _make_httpx_stream_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf"],
+                env={"BIBRA_URL_PROXY": "http://proxy.example.com:8080"},
+            )
+
+        assert result.exit_code == 0
+        mock_stream.assert_called_once_with(
+            "GET",
+            "https://example.com/paper.pdf",
+            proxy="http://proxy.example.com:8080",
+        )
+
+    def test_extract_url_no_proxy_when_not_set(self):
+        """Test that extract-url passes proxy=None when env var is not set."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.httpx.stream") as mock_stream,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_stream.return_value = _make_httpx_stream_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf"],
+            )
+
+        assert result.exit_code == 0
+        mock_stream.assert_called_once_with(
+            "GET",
+            "https://example.com/paper.pdf",
+            proxy=None,
+        )
+
 
 class TestMakeListTemplate:
     """Tests for the _make_list_template helper function."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -304,6 +304,8 @@ class TestServe:
             mock_uvicorn_run.assert_called_once_with(
                 "bibra.main:app", host="127.0.0.1", port=9999, reload=False
             )
+
+
 # Tests for the extract-url command.
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -545,6 +545,7 @@ class TestExtractUrl:
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
             patch("bibra.cli.httpx2.stream") as mock_stream,
+            patch("bibra.cli.get_url_proxy", return_value=None),
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from bibra.cli import _make_list_template, cli, extract, list_projects, serve
-from bibra.config import ConfigError
+from bibra.cli import (
+    _make_list_template,
+    cli,
+    extract,
+    extract_url,
+    list_projects,
+    serve,
+)
+from bibra.config import ConfigError, ProjectNotFoundError
 
 
 class TestCli:
@@ -297,6 +304,213 @@ class TestServe:
             mock_uvicorn_run.assert_called_once_with(
                 "bibra.main:app", host="127.0.0.1", port=9999, reload=False
             )
+
+
+def _make_urlopen_mock(chunks=(b"%PDF-1.4 dummy content", b"")):
+    """Build a mock for urllib.request.urlopen that yields the given chunks
+    from .read() and supports use as a context manager."""
+    mock_response = MagicMock()
+    mock_response.read.side_effect = list(chunks)
+
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_response
+    mock_cm.__exit__.return_value = False
+    return mock_cm
+
+
+def _make_backend(json_payload=None):
+    """Build a mock backend whose .extract() returns an object with a
+    model_dump_json method, matching what asyncio.run(backend.extract(...))
+    is expected to produce."""
+    if json_payload is None:
+        json_payload = {"title": "Some Paper", "authors": ["A. Author"]}
+
+    mock_result = MagicMock()
+    mock_result.model_dump_json.return_value = json.dumps(json_payload, indent=2)
+
+    mock_backend = MagicMock()
+
+    async def _extract(*args, **kwargs):
+        return mock_result
+
+    mock_backend.extract.side_effect = _extract
+    return mock_backend
+
+
+class TestExtractUrl:
+    """Tests for the extract-url command."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+
+    def test_extract_url_help(self):
+        """Test extract-url help output."""
+        result = self.runner.invoke(extract_url, ["--help"])
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Extract publication metadata" in result.output
+        assert "PROJECT_ID" in result.output
+        assert "URL" in result.output
+        assert "--output" in result.output
+        assert "-o" in result.output
+
+    def test_extract_url_missing_url(self):
+        """Test extract-url command with only a project id (missing URL)."""
+        result = self.runner.invoke(extract_url, ["test-project"])
+        assert result.exit_code != 0
+        assert result.exception
+
+    def test_extract_url_with_valid_url(self):
+        """Test extract-url command with a valid URL and successful extraction."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+
+        output = result.output.strip()
+        data = json.loads(output)
+        assert "title" in data or "authors" in data
+
+    def test_extract_url_with_output_option(self, tmp_path):
+        """Test extract-url command with --output option to write JSON to file."""
+        output_file = tmp_path / "output.json"
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                [
+                    "dummy",
+                    "https://example.com/paper.pdf",
+                    "--output",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Output written to" in result.output
+
+        assert output_file.exists()
+        content = output_file.read_text(encoding="utf-8")
+        data = json.loads(content.strip())
+        assert data is not None
+
+    def test_extract_url_with_short_output_option(self, tmp_path):
+        """Test extract-url command with -o short option."""
+        output_file = tmp_path / "output.json"
+
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url,
+                ["dummy", "https://example.com/paper.pdf", "-o", str(output_file)],
+            )
+
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Output written to" in result.output
+
+    def test_extract_url_with_nonexistent_project(self):
+        """Test extract-url command with a project that isn't found."""
+        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.side_effect = ProjectNotFoundError(
+                "Project 'nonexistent-project' not found"
+            )
+
+            result = self.runner.invoke(
+                extract_url,
+                ["nonexistent-project", "https://example.com/paper.pdf"],
+            )
+
+        assert result.exit_code != 0
+        assert result.exception
+        assert "not found" in result.output
+
+    def test_extract_url_config_error_converted_to_click_exception(self):
+        """Test that ConfigError while resolving the backend becomes a ClickException."""
+        with patch("bibra.cli.ProjectRegistry") as mock_registry_cls:
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.side_effect = ConfigError("Invalid config syntax")
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Invalid config syntax" in result.output
+
+    def test_extract_url_download_failure_converted_to_click_exception(self):
+        """Test that a failure while downloading the URL is wrapped as 'Extraction failed:'."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_registry.get_backend.return_value = _make_backend()
+            mock_urlopen.side_effect = OSError("Name or service not known")
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://bad.example.invalid/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Extraction failed:" in result.output
+
+    def test_extract_url_generic_exception_converted_to_click_exception(self):
+        """Test that a generic Exception during extraction is wrapped in
+        ClickException with the 'Extraction failed:' prefix."""
+        with (
+            patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
+            patch("bibra.cli.urllib.request.urlopen") as mock_urlopen,
+        ):
+            mock_registry = MagicMock()
+            mock_registry_cls.return_value = mock_registry
+            mock_backend = MagicMock()
+
+            async def _extract(*args, **kwargs):
+                raise RuntimeError("PDF corrupted")
+
+            mock_backend.extract.side_effect = _extract
+            mock_registry.get_backend.return_value = mock_backend
+            mock_urlopen.return_value = _make_urlopen_mock()
+
+            result = self.runner.invoke(
+                extract_url, ["dummy", "https://example.com/paper.pdf"]
+            )
+
+        assert result.exit_code != 0
+        assert "Extraction failed: PDF corrupted" in result.output
 
 
 class TestMakeListTemplate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,7 +307,7 @@ class TestServe:
 
 
 def _make_httpx_stream_mock(chunks=(b"%PDF-1.4 dummy content",)):
-    """Build a mock for httpx stream response that yields the given chunks."""
+    """Build a mock for httpx2 stream response that yields the given chunks."""
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "application/pdf"
     mock_response.status_code = 200
@@ -364,7 +364,7 @@ class TestExtractUrl:
         """Test extract-url command with a valid URL and successful extraction."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -388,7 +388,7 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -420,7 +420,7 @@ class TestExtractUrl:
 
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -472,9 +472,9 @@ class TestExtractUrl:
         """Test download failure is wrapped as 'Extraction failed:'."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
-            import httpx as _httpx
+            import httpx2 as _httpx
 
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -493,7 +493,7 @@ class TestExtractUrl:
         ClickException with the 'Extraction failed:' prefix."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -514,10 +514,10 @@ class TestExtractUrl:
         assert "Extraction failed: PDF corrupted" in result.output
 
     def test_extract_url_passes_proxy_when_set(self):
-        """Test that extract-url passes the proxy to httpx.stream when set."""
+        """Test that extract-url passes the proxy to httpx2.stream when set."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry
@@ -541,7 +541,7 @@ class TestExtractUrl:
         """Test that extract-url passes proxy=None when env var is not set."""
         with (
             patch("bibra.cli.ProjectRegistry") as mock_registry_cls,
-            patch("bibra.cli.httpx.stream") as mock_stream,
+            patch("bibra.cli.httpx2.stream") as mock_stream,
         ):
             mock_registry = MagicMock()
             mock_registry_cls.return_value = mock_registry

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -607,3 +607,25 @@ class TestInterpolateEnvVars:
     def test_unclosed_placeholder_with_trailing_text(self):
         """Test that an unclosed ${ followed by text is left as-is."""
         assert _interpolate_env_vars("prefix${BAR suffix") == "prefix${BAR suffix"
+
+
+class TestGetUrlProxy:
+    """Tests for get_url_proxy helper function."""
+
+    def test_returns_proxy_when_set(self, monkeypatch):
+        """Test that get_url_proxy returns the proxy URL when set."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+        from bibra.config import get_url_proxy
+
+        assert get_url_proxy() == "http://proxy.example.com:8080"
+
+    def test_returns_none_when_not_set(self, monkeypatch):
+        """Test that get_url_proxy returns None when the env var is not set."""
+        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
+        # Re-import to get fresh import
+        import importlib
+
+        import bibra.config
+
+        importlib.reload(bibra.config)
+        assert bibra.config.get_url_proxy() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -621,11 +621,7 @@ class TestGetUrlProxy:
 
     def test_returns_none_when_not_set(self, monkeypatch):
         """Test that get_url_proxy returns None when the env var is not set."""
+        from bibra.config import get_url_proxy
+
         monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
-        # Re-import to get fresh import
-        import importlib
-
-        from bibra import config as bibra_config
-
-        importlib.reload(bibra_config)
-        assert bibra_config.get_url_proxy() is None
+        assert get_url_proxy() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -672,7 +672,7 @@ class TestLoadUrlFetchPolicy:
         assert policy.schemes == ("https",)
         assert policy.content_types == ("application/pdf",)
         assert policy.max_bytes == 50 * 1024 * 1024
-        assert policy.timeout == 30.0
+        assert policy.timeout == 30
         assert policy.max_redirects == 5
         assert policy.allow_ip_hosts is False
 
@@ -786,12 +786,12 @@ class TestLoadUrlFetchPolicy:
         assert policy.max_bytes == 50 * 1024 * 1024
 
     def test_timeout_custom(self, monkeypatch):
-        """BIBRA_URL_TIMEOUT accepts a positive float."""
-        monkeypatch.setenv("BIBRA_URL_TIMEOUT", "1.5")
+        """BIBRA_URL_TIMEOUT accepts a positive integer (seconds)."""
+        monkeypatch.setenv("BIBRA_URL_TIMEOUT", "2")
 
         policy = load_url_fetch_policy()
 
-        assert policy.timeout == 1.5
+        assert policy.timeout == 2
 
     def test_timeout_invalid_falls_back_to_default(self, monkeypatch):
         """A non-numeric BIBRA_URL_TIMEOUT falls back to the default."""
@@ -799,7 +799,7 @@ class TestLoadUrlFetchPolicy:
 
         policy = load_url_fetch_policy()
 
-        assert policy.timeout == 30.0
+        assert policy.timeout == 30
 
     def test_max_redirects_custom(self, monkeypatch):
         """BIBRA_URL_MAX_REDIRECTS accepts a positive integer."""
@@ -826,4 +826,4 @@ class TestLoadUrlFetchPolicy:
         policy = load_url_fetch_policy()
 
         with pytest.raises(AttributeError):
-            policy.timeout = 1.0
+            policy.timeout = 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,14 +7,16 @@ import pytest
 from bibra.backend.config import parse_bool_or_str, parse_int_or_str
 from bibra.backend.dummy import DummyBackend
 from bibra.config import (
-    URL_FETCH_DIRECT,
     BackendConfigError,
     ConfigFileNotFoundError,
     ConfigParseError,
     ProjectConfig,
     ProjectRegistry,
-    UrlFetchPolicy,
     _interpolate_env_vars,
+)
+from bibra.net_security import (
+    URL_FETCH_DIRECT,
+    UrlFetchPolicy,
     load_url_fetch_policy,
 )
 
@@ -618,27 +620,27 @@ class TestGetUrlProxy:
     def test_returns_proxy_when_set(self, monkeypatch):
         """Test that get_url_proxy returns the proxy URL when set."""
         monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
-        from bibra.config import get_url_proxy
+        from bibra.net_security import get_url_proxy
 
         assert get_url_proxy() == "http://proxy.example.com:8080"
 
     def test_returns_none_when_not_set(self, monkeypatch):
         """Test that get_url_proxy returns None when the env var is not set."""
-        from bibra.config import get_url_proxy
+        from bibra.net_security import get_url_proxy
 
         monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
         assert get_url_proxy() is None
 
     def test_returns_none_when_empty(self, monkeypatch):
         """Test that an empty BIBRA_URL_PROXY is normalized to None."""
-        from bibra.config import get_url_proxy
+        from bibra.net_security import get_url_proxy
 
         monkeypatch.setenv("BIBRA_URL_PROXY", "")
         assert get_url_proxy() is None
 
     def test_returns_none_when_whitespace(self, monkeypatch):
         """Test that a whitespace-only BIBRA_URL_PROXY is normalized to None."""
-        from bibra.config import get_url_proxy
+        from bibra.net_security import get_url_proxy
 
         monkeypatch.setenv("BIBRA_URL_PROXY", "   \t\n  ")
         assert get_url_proxy() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,6 @@ from bibra.config import (
     ConfigParseError,
     ProjectConfig,
     ProjectRegistry,
-    _interpolate_env_vars,
 )
 from bibra.net_security import (
     URL_FETCH_DIRECT,
@@ -567,51 +566,6 @@ class TestParseIntOrStr:
     ):
         assert parse_int_or_str("   ") == 0
         assert "Unrecognized int value" in caplog.text
-
-
-class TestInterpolateEnvVars:
-    """Tests for _interpolate_env_vars."""
-
-    def test_none_returns_none(self):
-        """Test that None input returns None."""
-        assert _interpolate_env_vars(None) is None
-
-    def test_non_string_int_returns_unchanged(self):
-        """Test that non-string values (int) are returned unchanged."""
-        assert _interpolate_env_vars(42) == 42
-
-    def test_non_string_float_returns_unchanged(self):
-        """Test that non-string values (float) are returned unchanged."""
-        assert _interpolate_env_vars(3.14) == 3.14
-
-    def test_non_string_bool_returns_unchanged(self):
-        """Test that non-string values (bool) are returned unchanged."""
-        assert _interpolate_env_vars(True) is True
-        assert _interpolate_env_vars(False) is False
-
-    def test_non_string_list_returns_unchanged(self):
-        """Test that non-string values (list) are returned unchanged."""
-        assert _interpolate_env_vars([1, 2, 3]) == [1, 2, 3]
-
-    def test_string_with_no_placeholders_returns_unchanged(self):
-        """Test that strings without placeholders are returned unchanged."""
-        assert _interpolate_env_vars("hello world") == "hello world"
-
-    def test_unclosed_placeholder_returns_unchanged(self):
-        """Test that strings with ${ but no closing } are returned unchanged."""
-        assert _interpolate_env_vars("${FOO") == "${FOO"
-
-    def test_unclosed_placeholder_mid_string_returns_unchanged(self):
-        """Test that ${ without } in the middle of a string is returned unchanged."""
-        assert _interpolate_env_vars("prefix ${BAR suffix") == "prefix ${BAR suffix"
-
-    def test_unclosed_placeholder_preserved(self):
-        """Test that an unclosed ${ without } is left as-is."""
-        assert _interpolate_env_vars("${FOO") == "${FOO"
-
-    def test_unclosed_placeholder_with_trailing_text(self):
-        """Test that an unclosed ${ followed by text is left as-is."""
-        assert _interpolate_env_vars("prefix${BAR suffix") == "prefix${BAR suffix"
 
 
 class TestGetUrlProxy:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -625,7 +625,7 @@ class TestGetUrlProxy:
         # Re-import to get fresh import
         import importlib
 
-        import bibra.config
+        from bibra import config as bibra_config
 
-        importlib.reload(bibra.config)
-        assert bibra.config.get_url_proxy() is None
+        importlib.reload(bibra_config)
+        assert bibra_config.get_url_proxy() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import pytest
 from bibra.backend.config import parse_bool_or_str, parse_int_or_str
 from bibra.backend.dummy import DummyBackend
 from bibra.config import (
+    URL_FETCH_DIRECT,
     BackendConfigError,
     ConfigFileNotFoundError,
     ConfigParseError,
@@ -709,6 +710,32 @@ class TestLoadUrlFetchPolicy:
 
         assert policy.proxy is None
         assert policy.proxy_required is True
+
+    def test_cli_fallback_unset_proxy_means_direct(self, monkeypatch):
+        """cli_fallback=True: an unset proxy is treated as 'direct'."""
+        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
+
+        policy = load_url_fetch_policy(cli_fallback=True)
+
+        assert policy.proxy == URL_FETCH_DIRECT
+        assert policy.proxy_required is False
+
+    def test_cli_fallback_explicit_proxy_unchanged(self, monkeypatch):
+        """cli_fallback=True never overrides an explicitly set proxy."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+
+        policy = load_url_fetch_policy(cli_fallback=True)
+
+        assert policy.proxy == "http://proxy.example.com:8080"
+
+    def test_cli_fallback_blank_proxy_means_direct(self, monkeypatch):
+        """cli_fallback=True: a blank (whitespace) proxy is treated as
+        'direct', same as unset."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "   ")
+
+        policy = load_url_fetch_policy(cli_fallback=True)
+
+        assert policy.proxy == URL_FETCH_DIRECT
 
     def test_schemes_custom(self, monkeypatch):
         """BIBRA_URL_SCHEMES is parsed as a comma-separated list."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -568,38 +568,6 @@ class TestParseIntOrStr:
         assert "Unrecognized int value" in caplog.text
 
 
-class TestGetUrlProxy:
-    """Tests for get_url_proxy helper function."""
-
-    def test_returns_proxy_when_set(self, monkeypatch):
-        """Test that get_url_proxy returns the proxy URL when set."""
-        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
-        from bibra.net_security import get_url_proxy
-
-        assert get_url_proxy() == "http://proxy.example.com:8080"
-
-    def test_returns_none_when_not_set(self, monkeypatch):
-        """Test that get_url_proxy returns None when the env var is not set."""
-        from bibra.net_security import get_url_proxy
-
-        monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
-        assert get_url_proxy() is None
-
-    def test_returns_none_when_empty(self, monkeypatch):
-        """Test that an empty BIBRA_URL_PROXY is normalized to None."""
-        from bibra.net_security import get_url_proxy
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "")
-        assert get_url_proxy() is None
-
-    def test_returns_none_when_whitespace(self, monkeypatch):
-        """Test that a whitespace-only BIBRA_URL_PROXY is normalized to None."""
-        from bibra.net_security import get_url_proxy
-
-        monkeypatch.setenv("BIBRA_URL_PROXY", "   \t\n  ")
-        assert get_url_proxy() is None
-
-
 class TestLoadUrlFetchPolicy:
     """Tests for load_url_fetch_policy and UrlFetchPolicy."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,9 @@ from bibra.config import (
     ConfigParseError,
     ProjectConfig,
     ProjectRegistry,
+    UrlFetchPolicy,
     _interpolate_env_vars,
+    load_url_fetch_policy,
 )
 
 
@@ -639,3 +641,162 @@ class TestGetUrlProxy:
 
         monkeypatch.setenv("BIBRA_URL_PROXY", "   \t\n  ")
         assert get_url_proxy() is None
+
+
+class TestLoadUrlFetchPolicy:
+    """Tests for load_url_fetch_policy and UrlFetchPolicy."""
+
+    URL_ENV_VARS = (
+        "BIBRA_URL_PROXY",
+        "BIBRA_URL_SCHEMES",
+        "BIBRA_URL_CONTENT_TYPES",
+        "BIBRA_URL_MAX_BYTES",
+        "BIBRA_URL_TIMEOUT",
+        "BIBRA_URL_MAX_REDIRECTS",
+        "BIBRA_URL_ALLOW_IP_HOSTS",
+    )
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        for var in self.URL_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_defaults_when_nothing_set(self):
+        """Default policy: proxy required, https-only, PDF only."""
+        policy = load_url_fetch_policy()
+
+        assert isinstance(policy, UrlFetchPolicy)
+        assert policy.proxy is None
+        assert policy.proxy_required is True
+        assert policy.schemes == ("https",)
+        assert policy.content_types == ("application/pdf",)
+        assert policy.max_bytes == 50 * 1024 * 1024
+        assert policy.timeout == 30.0
+        assert policy.max_redirects == 5
+        assert policy.allow_ip_hosts is False
+
+    def test_proxy_url(self, monkeypatch):
+        """A non-sentinel BIBRA_URL_PROXY value is used as the proxy URL."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.proxy == "http://proxy.example.com:8080"
+        assert policy.proxy_required is False
+
+    def test_proxy_direct_sentinel(self, monkeypatch):
+        """The literal value 'direct' enables direct egress with validation."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.proxy == "direct"
+        assert policy.proxy_required is False
+
+    def test_proxy_direct_is_case_sensitive(self, monkeypatch):
+        """'Direct' is not the sentinel and is treated as a proxy URL."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "Direct")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.proxy == "Direct"
+
+    def test_proxy_blank_means_refused(self, monkeypatch):
+        """A blank BIBRA_URL_PROXY means URL fetching is refused."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "   ")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.proxy is None
+        assert policy.proxy_required is True
+
+    def test_schemes_custom(self, monkeypatch):
+        """BIBRA_URL_SCHEMES is parsed as a comma-separated list."""
+        monkeypatch.setenv("BIBRA_URL_SCHEMES", "https, http ,ftp")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.schemes == ("https", "http", "ftp")
+
+    def test_schemes_blank_falls_back_to_default(self, monkeypatch):
+        """A blank BIBRA_URL_SCHEMES falls back to the https default."""
+        monkeypatch.setenv("BIBRA_URL_SCHEMES", " , ,")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.schemes == ("https",)
+
+    def test_content_types_custom(self, monkeypatch):
+        """BIBRA_URL_CONTENT_TYPES is parsed as a comma-separated list."""
+        monkeypatch.setenv("BIBRA_URL_CONTENT_TYPES", "application/pdf, image/png")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.content_types == ("application/pdf", "image/png")
+
+    def test_max_bytes_custom(self, monkeypatch):
+        """BIBRA_URL_MAX_BYTES accepts a positive integer."""
+        monkeypatch.setenv("BIBRA_URL_MAX_BYTES", "1024")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.max_bytes == 1024
+
+    def test_max_bytes_invalid_falls_back_to_default(self, monkeypatch):
+        """A non-numeric BIBRA_URL_MAX_BYTES falls back to the default."""
+        monkeypatch.setenv("BIBRA_URL_MAX_BYTES", "huge")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.max_bytes == 50 * 1024 * 1024
+
+    def test_max_bytes_non_positive_falls_back_to_default(self, monkeypatch):
+        """A non-positive BIBRA_URL_MAX_BYTES falls back to the default."""
+        monkeypatch.setenv("BIBRA_URL_MAX_BYTES", "-5")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.max_bytes == 50 * 1024 * 1024
+
+    def test_timeout_custom(self, monkeypatch):
+        """BIBRA_URL_TIMEOUT accepts a positive float."""
+        monkeypatch.setenv("BIBRA_URL_TIMEOUT", "1.5")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.timeout == 1.5
+
+    def test_timeout_invalid_falls_back_to_default(self, monkeypatch):
+        """A non-numeric BIBRA_URL_TIMEOUT falls back to the default."""
+        monkeypatch.setenv("BIBRA_URL_TIMEOUT", "soon")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.timeout == 30.0
+
+    def test_max_redirects_custom(self, monkeypatch):
+        """BIBRA_URL_MAX_REDIRECTS accepts a positive integer."""
+        monkeypatch.setenv("BIBRA_URL_MAX_REDIRECTS", "2")
+
+        policy = load_url_fetch_policy()
+
+        assert policy.max_redirects == 2
+
+    def test_allow_ip_hosts_truthy_values(self, monkeypatch):
+        """BIBRA_URL_ALLOW_IP_HOSTS accepts common truthy spellings."""
+        for value in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("BIBRA_URL_ALLOW_IP_HOSTS", value)
+            assert load_url_fetch_policy().allow_ip_hosts is True
+
+    def test_allow_ip_hosts_falsy_values(self, monkeypatch):
+        """BIBRA_URL_ALLOW_IP_HOSTS accepts common falsy spellings."""
+        for value in ("0", "false", "no", "off", "garbage"):
+            monkeypatch.setenv("BIBRA_URL_ALLOW_IP_HOSTS", value)
+            assert load_url_fetch_policy().allow_ip_hosts is False
+
+    def test_policy_is_frozen(self):
+        """UrlFetchPolicy instances are immutable."""
+        policy = load_url_fetch_policy()
+
+        with pytest.raises(AttributeError):
+            policy.timeout = 1.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -625,3 +625,17 @@ class TestGetUrlProxy:
 
         monkeypatch.delenv("BIBRA_URL_PROXY", raising=False)
         assert get_url_proxy() is None
+
+    def test_returns_none_when_empty(self, monkeypatch):
+        """Test that an empty BIBRA_URL_PROXY is normalized to None."""
+        from bibra.config import get_url_proxy
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "")
+        assert get_url_proxy() is None
+
+    def test_returns_none_when_whitespace(self, monkeypatch):
+        """Test that a whitespace-only BIBRA_URL_PROXY is normalized to None."""
+        from bibra.config import get_url_proxy
+
+        monkeypatch.setenv("BIBRA_URL_PROXY", "   \t\n  ")
+        assert get_url_proxy() is None

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -108,16 +108,40 @@ def test_parse_int_env(monkeypatch, raw: str, expected: int):
     [
         ("1", True),
         ("true", True),
+        ("TRUE", True),
         ("yes", True),
         ("on", True),
-        ("", False),
         ("0", False),
         ("false", False),
+        ("no", False),
         ("off", False),
-        ("nope", False),
     ],
 )
-def test_parse_bool_env(monkeypatch, raw: str, expected: bool):
-    """parse_bool_env accepts 1/true/yes/on, default otherwise."""
+def test_parse_bool_env_recognized(monkeypatch, raw: str, expected: bool):
+    """parse_bool_env maps recognized true/false values exactly."""
     monkeypatch.setenv("BIBRA_TEST_BOOL", raw)
     assert parse_bool_env("BIBRA_TEST_BOOL", False) is expected
+    assert parse_bool_env("BIBRA_TEST_BOOL", True) is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "default", "expected"),
+    [
+        # Unset or blank -> default
+        ("", True, True),
+        ("", False, False),
+        ("   ", True, True),
+        # Malformed values fall back to the default (not silently False)
+        ("nope", True, True),
+        ("TRUE2", True, True),
+        ("truly", False, False),
+        ("1true", True, True),
+        ("onoff", False, False),
+    ],
+)
+def test_parse_bool_env_malformed_falls_back(
+    monkeypatch, raw: str, default: bool, expected: bool
+):
+    """Unset, blank, or malformed values fall back to the default."""
+    monkeypatch.setenv("BIBRA_TEST_BOOL", raw)
+    assert parse_bool_env("BIBRA_TEST_BOOL", default) is expected

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,123 @@
+"""Tests for generic environment variable helpers in bibra.env."""
+
+import pytest
+
+from bibra.env import (
+    interpolate_dict_values,
+    interpolate_env_vars,
+    parse_bool_env,
+    parse_int_env,
+    parse_list_env,
+)
+
+
+class TestInterpolateEnvVars:
+    """Tests for interpolate_env_vars."""
+
+    def test_none_returns_none(self):
+        """Test that None input returns None."""
+        assert interpolate_env_vars(None) is None
+
+    def test_non_string_int_returns_unchanged(self):
+        """Test that non-string values (int) are returned unchanged."""
+        assert interpolate_env_vars(42) == 42
+
+    def test_non_string_float_returns_unchanged(self):
+        """Test that non-string values (float) are returned unchanged."""
+        assert interpolate_env_vars(3.14) == 3.14
+
+    def test_non_string_bool_returns_unchanged(self):
+        """Test that non-string values (bool) are returned unchanged."""
+        assert interpolate_env_vars(True) is True
+        assert interpolate_env_vars(False) is False
+
+    def test_non_string_list_returns_unchanged(self):
+        """Test that non-string values (list) are returned unchanged."""
+        assert interpolate_env_vars([1, 2, 3]) == [1, 2, 3]
+
+    def test_string_with_no_placeholders_returns_unchanged(self):
+        """Test that strings without placeholders are returned unchanged."""
+        assert interpolate_env_vars("hello world") == "hello world"
+
+    def test_unclosed_placeholder_returns_unchanged(self):
+        """Test that strings with ${ but no closing } are returned unchanged."""
+        assert interpolate_env_vars("${FOO") == "${FOO"
+
+    def test_unclosed_placeholder_mid_string_returns_unchanged(self):
+        """Test that ${ without } in the middle of a string is returned unchanged."""
+        assert interpolate_env_vars("prefix ${BAR suffix") == "prefix ${BAR suffix"
+
+    def test_unclosed_placeholder_with_trailing_text(self):
+        """Test that an unclosed ${ followed by text is left as-is."""
+        assert interpolate_env_vars("prefix${BAR suffix") == "prefix${BAR suffix"
+
+    def test_set_variable_is_interpolated(self, monkeypatch):
+        """Test that a set ${VAR} placeholder is replaced by its value."""
+        monkeypatch.setenv("BIBRA_TEST_ENV", "value")
+        assert interpolate_env_vars("pre-${BIBRA_TEST_ENV}-post") == "pre-value-post"
+
+    def test_unset_variable_placeholder_preserved(self, monkeypatch):
+        """Test that an unset ${VAR} placeholder is preserved."""
+        monkeypatch.delenv("BIBRA_TEST_UNSET", raising=False)
+        assert interpolate_env_vars("${BIBRA_TEST_UNSET}") == "${BIBRA_TEST_UNSET}"
+
+
+class TestInterpolateDictValues:
+    """Tests for interpolate_dict_values."""
+
+    def test_interpolates_string_values_only(self, monkeypatch):
+        """Only string values are interpolated; others pass through."""
+        monkeypatch.setenv("BIBRA_TEST_ENV", "x")
+
+        result = interpolate_dict_values(
+            {"a": "${BIBRA_TEST_ENV}", "b": 5, "c": None, "d": "plain"}
+        )
+        assert result == {"a": "x", "b": 5, "c": None, "d": "plain"}
+
+    def test_empty_dict(self):
+        """An empty dict is returned unchanged."""
+        assert interpolate_dict_values({}) == {}
+
+
+@pytest.mark.parametrize(
+    ("raw", "default", "expected"),
+    [
+        ("", ["fallback"], ("fallback",)),
+        ("a, b", ["fallback"], ("a", "b")),
+        (" ,A ,", ["fallback"], ("a",)),
+    ],
+)
+def test_parse_list_env(monkeypatch, raw: str, default, expected):
+    """parse_list_env splits, strips, lowercases; falls back on blank."""
+    monkeypatch.setenv("BIBRA_TEST_LIST", raw)
+    assert parse_list_env("BIBRA_TEST_LIST", list(default)) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("5", 5), ("", 7), ("-3", 7), ("abc", 7)],
+)
+def test_parse_int_env(monkeypatch, raw: str, expected: int):
+    """parse_int_env returns positive ints, default otherwise."""
+    monkeypatch.setenv("BIBRA_TEST_INT", raw)
+    assert parse_int_env("BIBRA_TEST_INT", 7) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("off", False),
+        ("nope", False),
+    ],
+)
+def test_parse_bool_env(monkeypatch, raw: str, expected: bool):
+    """parse_bool_env accepts 1/true/yes/on, default otherwise."""
+    monkeypatch.setenv("BIBRA_TEST_BOOL", raw)
+    assert parse_bool_env("BIBRA_TEST_BOOL", False) is expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,16 +1,5 @@
 """Integration tests using TestClient."""
 
-import pytest
-from fastapi.testclient import TestClient
-
-from bibra.main import app
-
-
-@pytest.fixture
-def client():
-    """Create a test client for the FastAPI app."""
-    return TestClient(app)
-
 
 class TestRootEndpoint:
     """Tests for the root endpoint."""

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -225,6 +225,14 @@ class TestValidateUrl:
         with pytest.raises(UrlPolicyError):
             validate_url("https://example.com:badport/x", policy)
 
+    def test_malformed_port_with_query_rejected_generically(self):
+        """A malformed port combined with userinfo/query yields a
+        UrlPolicyError, not a parser exception from redact_url()."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://user:tok@example.com:99999/x?q=1", policy)
+
     @pytest.mark.parametrize(
         ("url",),
         [
@@ -303,6 +311,31 @@ class TestRedactUrl:
             "https://api.example.com/reports/q1.pdf [userinfo/query/fragment redacted]"
         )
         assert "ghp_abc123" not in redact_url(url)
+
+    def test_password_only_userinfo_stripped_with_marker(self):
+        """A password with an empty username is redacted as well."""
+        url = "https://:ghp_pw_only@api.example.com/doc.pdf"
+        assert redact_url(url) == (
+            "https://api.example.com/doc.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "ghp_pw_only" not in redact_url(url)
+
+    def test_empty_password_userinfo_stripped_with_marker(self):
+        """An empty password with a username is redacted as well."""
+        url = "https://user:@api.example.com/doc.pdf"
+        assert redact_url(url) == (
+            "https://api.example.com/doc.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "user:" not in redact_url(url)
+
+    def test_malformed_port_does_not_raise(self):
+        """A port that fails to parse does not raise; the host is kept
+        (without the port) and other secrets are still stripped."""
+        url = "https://api.example.com:99999/doc.pdf?signature=HMAC"
+        assert redact_url(url) == (
+            "https://api.example.com/doc.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "HMAC" not in redact_url(url)
 
     def test_query_stripped_with_marker(self):
         """Tokens in the query string are removed."""
@@ -384,6 +417,16 @@ class TestValidateUrlLogsRedacted:
 
         with caplog.at_level("WARNING"), pytest.raises(ProxyRequiredError):
             validate_url(self.SENSITIVE_URL, policy)
+
+        self._assert_logs_redacted(caplog, "api.example.com/doc.pdf")
+
+    def test_password_only_userinfo_rejection_logs_redacted(self, caplog):
+        """A password-only userinfo is never logged verbatim on rejection."""
+        policy = make_policy()
+        url = "http://:supersecrettoken@api.example.com/doc.pdf?key=abc123"
+
+        with caplog.at_level("WARNING"), pytest.raises(UrlPolicyError):
+            validate_url(url, policy)
 
         self._assert_logs_redacted(caplog, "api.example.com/doc.pdf")
 

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -265,6 +265,13 @@ class TestValidateUrl:
         with pytest.raises(UrlPolicyError):
             validate_url("https://2130706433/paper.pdf", policy)
 
+    def test_numeric_hostname_rejected_even_when_ip_hosts_allowed(self):
+        """Numeric hostnames stay rejected even with allow_ip_hosts=True."""
+        policy = make_policy(allow_ip_hosts=True)
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://2130706433/paper.pdf", policy)
+
     def test_unparseable_numeric_hostname_rejected(self):
         """A numeric hostname that is not a valid IPv4 literal is rejected.
 

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -305,8 +305,6 @@ class TestIsPdf:
     def test_non_pdf_rejected(self, label: str, data: bytes):
         """Non-PDF content is rejected."""
         assert is_pdf(data) is False
-        """Non-PDF content is rejected."""
-        assert is_pdf(data) is False
 
     def test_magic_bytes_beyond_search_window(self):
         """%PDF beyond the 1024-byte search window is not recognized."""

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -9,7 +9,6 @@ import ipaddress
 import pytest
 
 from bibra.net_security import (
-    ContentValidator,
     ProxyRequiredError,
     UrlFetchPolicy,
     UrlPolicyError,
@@ -337,27 +336,6 @@ class TestIsPdf:
         data = b"x" * 1010 + b"%PDF-1.7"
 
         assert is_pdf(data) is True
-
-
-class TestContentValidatorProtocol:
-    """Tests that validators plug into the ContentValidator protocol."""
-
-    def test_is_pdf_satisfies_protocol(self):
-        """is_pdf is structurally compatible with ContentValidator."""
-        validator: ContentValidator = is_pdf
-
-        assert validator(b"%PDF-1.7") is True
-
-    def test_custom_validator(self):
-        """A custom validator (e.g. for a future file type) can be passed."""
-
-        def is_png(data: bytes) -> bool:
-            return data.startswith(b"\x89PNG")
-
-        validator: ContentValidator = is_png
-
-        assert validator(b"\x89PNG\r\n\x1a\n") is True
-        assert validator(b"%PDF-1.7") is False
 
 
 class TestPolicyIntegration:

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -292,16 +292,19 @@ class TestIsPdf:
         assert is_pdf(b"\xef\xbb\xbf%PDF-1.5\n") is True
 
     @pytest.mark.parametrize(
-        ["data"],
+        ["label", "data"],
         [
-            [b"PK\x03\x04"],  # zip
-            [b"\x89PNG\r\n\x1a\n"],  # png
-            [b"<html>not a pdf</html>"],
-            [b""],
-            [b"\x00" * 2048],
+            ["zip", b"PK\x03\x04"],
+            ["png", b"\x89PNG\r\n\x1a\n"],
+            ["html", b"<html>not a pdf</html>"],
+            ["empty", b""],
+            ["null_bytes", b"\x00" * 2048],
         ],
+        ids=["zip", "png", "html", "empty", "null_bytes"],
     )
-    def test_non_pdf_rejected(self, data: bytes):
+    def test_non_pdf_rejected(self, label: str, data: bytes):
+        """Non-PDF content is rejected."""
+        assert is_pdf(data) is False
         """Non-PDF content is rejected."""
         assert is_pdf(data) is False
 

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -17,6 +17,7 @@ from bibra.net_security import (
     is_pdf,
     load_url_fetch_policy,
     parse_ip_host,
+    redact_url,
     validate_url,
 )
 
@@ -293,6 +294,99 @@ class TestValidateUrl:
 
         assert "example.com" not in str(exc_info.value)
         assert "secret.pdf" not in str(exc_info.value)
+
+
+class TestRedactUrl:
+    """Tests for redact_url (log-safe URL representation)."""
+
+    def test_userinfo_stripped_with_marker(self):
+        """Credentials in the userinfo component are removed."""
+        url = "https://user:ghp_abc123@api.example.com/reports/q1.pdf"
+        assert redact_url(url) == (
+            "https://api.example.com/reports/q1.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "ghp_abc123" not in redact_url(url)
+
+    def test_query_stripped_with_marker(self):
+        """Tokens in the query string are removed."""
+        url = "https://api.example.com/doc.pdf?api_key=sk_live_9988"
+        assert redact_url(url) == (
+            "https://api.example.com/doc.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "sk_live_9988" not in redact_url(url)
+
+    def test_fragment_stripped_with_marker(self):
+        """Fragments are removed as well."""
+        url = "https://example.com/doc.pdf#access=token123"
+        assert redact_url(url) == (
+            "https://example.com/doc.pdf [userinfo/query/fragment redacted]"
+        )
+        assert "token123" not in redact_url(url)
+
+    def test_port_and_path_preserved(self):
+        """Host, port, and path survive redaction for diagnosability."""
+        url = "https://cdn.files.example.net:8080/pdfs/98765/paper.pdf?signature=HMAC"
+        assert redact_url(url) == (
+            "https://cdn.files.example.net:8080/pdfs/98765/paper.pdf"
+            " [userinfo/query/fragment redacted]"
+        )
+
+    def test_clean_url_returned_unchanged(self):
+        """A URL with no userinfo/query/fragment is byte-identical."""
+        url = "https://example.com:443/doc.pdf"
+        assert redact_url(url) == url
+
+    def test_clean_url_no_marker(self):
+        """No redaction marker is added when nothing was stripped."""
+        assert "redacted" not in redact_url("https://example.com/doc.pdf")
+
+    def test_unparseable_input_returned_unchanged(self):
+        """Input that urlsplit cannot parse is returned as-is."""
+        url = "not a url at all"
+        assert redact_url(url) == url
+
+
+class TestValidateUrlLogsRedacted:
+    """Regression tests: rejection diagnostics must not persist secrets.
+
+    URLs may carry credentials in userinfo/query strings; every log
+    record emitted on a rejection path must be free of them.
+    """
+
+    SENSITIVE_URL = "https://user:supersecrettoken@api.example.com/doc.pdf?key=abc123"
+
+    def test_scheme_rejection_logs_redacted(self, caplog):
+        """A scheme rejection never logs userinfo or query verbatim."""
+        policy = make_policy()
+
+        with caplog.at_level("WARNING"), pytest.raises(UrlPolicyError):
+            validate_url("http://" + self.SENSITIVE_URL.split("://", 1)[1], policy)
+
+        assert "supersecrettoken" not in caplog.text
+        assert "key=abc123" not in caplog.text
+        assert "api.example.com/doc.pdf" in caplog.text
+
+    def test_blocked_ip_rejection_logs_redacted(self, caplog):
+        """A blocked-IP rejection never logs userinfo or query verbatim."""
+        policy = make_policy()
+        url = "https://user:supersecrettoken@169.254.169.254/meta?key=abc123"
+
+        with caplog.at_level("WARNING"), pytest.raises(UrlPolicyError):
+            validate_url(url, policy)
+
+        assert "supersecrettoken" not in caplog.text
+        assert "key=abc123" not in caplog.text
+        assert "169.254.169.254" in caplog.text
+
+    def test_proxy_required_rejection_logs_redacted(self, caplog):
+        """The 503 no-proxy path never logs userinfo or query verbatim."""
+        policy = make_policy(proxy=None)
+
+        with caplog.at_level("WARNING"), pytest.raises(ProxyRequiredError):
+            validate_url(self.SENSITIVE_URL, policy)
+
+        assert "supersecrettoken" not in caplog.text
+        assert "key=abc123" not in caplog.text
 
 
 class TestIsPdf:

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -173,20 +173,17 @@ class TestValidateUrl:
     """Tests for validate_url (static, pre-flight URL validation)."""
 
     def test_refused_when_proxy_not_configured(self):
-        """With no proxy configured, every URL is refused."""
+        """With no proxy configured, every URL is refused.
+
+        ProxyRequiredError is a UrlPolicyError but carries its own type and
+        a message that names the env var to fix.
+        """
         policy = make_policy(proxy=None)
 
-        with pytest.raises(ProxyRequiredError):
+        with pytest.raises(ProxyRequiredError) as exc_info:
             validate_url("https://example.com/paper.pdf", policy)
 
-    def test_proxy_required_is_distinguishable(self):
-        """ProxyRequiredError is a UrlPolicyError but carries its own type."""
-        policy = make_policy(proxy=None)
-
-        with pytest.raises(UrlPolicyError) as exc_info:
-            validate_url("https://example.com/paper.pdf", policy)
-
-        assert isinstance(exc_info.value, ProxyRequiredError)
+        assert isinstance(exc_info.value, UrlPolicyError)
         assert "BIBRA_URL_PROXY" in str(exc_info.value)
 
     def test_https_url_accepted(self):
@@ -355,6 +352,13 @@ class TestValidateUrlLogsRedacted:
 
     SENSITIVE_URL = "https://user:supersecrettoken@api.example.com/doc.pdf?key=abc123"
 
+    @staticmethod
+    def _assert_logs_redacted(caplog, host):
+        """No secret substrings in the logs; the host is still diagnosable."""
+        assert "supersecrettoken" not in caplog.text
+        assert "key=abc123" not in caplog.text
+        assert host in caplog.text
+
     def test_scheme_rejection_logs_redacted(self, caplog):
         """A scheme rejection never logs userinfo or query verbatim."""
         policy = make_policy()
@@ -362,9 +366,7 @@ class TestValidateUrlLogsRedacted:
         with caplog.at_level("WARNING"), pytest.raises(UrlPolicyError):
             validate_url("http://" + self.SENSITIVE_URL.split("://", 1)[1], policy)
 
-        assert "supersecrettoken" not in caplog.text
-        assert "key=abc123" not in caplog.text
-        assert "api.example.com/doc.pdf" in caplog.text
+        self._assert_logs_redacted(caplog, "api.example.com/doc.pdf")
 
     def test_blocked_ip_rejection_logs_redacted(self, caplog):
         """A blocked-IP rejection never logs userinfo or query verbatim."""
@@ -374,9 +376,7 @@ class TestValidateUrlLogsRedacted:
         with caplog.at_level("WARNING"), pytest.raises(UrlPolicyError):
             validate_url(url, policy)
 
-        assert "supersecrettoken" not in caplog.text
-        assert "key=abc123" not in caplog.text
-        assert "169.254.169.254" in caplog.text
+        self._assert_logs_redacted(caplog, "169.254.169.254")
 
     def test_proxy_required_rejection_logs_redacted(self, caplog):
         """The 503 no-proxy path never logs userinfo or query verbatim."""
@@ -385,8 +385,7 @@ class TestValidateUrlLogsRedacted:
         with caplog.at_level("WARNING"), pytest.raises(ProxyRequiredError):
             validate_url(self.SENSITIVE_URL, policy)
 
-        assert "supersecrettoken" not in caplog.text
-        assert "key=abc123" not in caplog.text
+        self._assert_logs_redacted(caplog, "api.example.com/doc.pdf")
 
 
 class TestIsPdf:

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -1,0 +1,377 @@
+"""Tests for the SSRF validation layer in bibra/net_security.py.
+
+These are pure unit tests: no network I/O is performed. The fetch layer
+that builds on top of this module is tested in a later step.
+"""
+
+import ipaddress
+
+import pytest
+
+from bibra.config import UrlFetchPolicy, load_url_fetch_policy
+from bibra.net_security import (
+    ContentValidator,
+    ProxyRequiredError,
+    UrlPolicyError,
+    is_blocked_ip,
+    is_ip_literal,
+    is_pdf,
+    parse_ip_host,
+    validate_url,
+)
+
+
+def make_policy(**overrides) -> UrlFetchPolicy:
+    """Build a UrlFetchPolicy with sensible test defaults.
+
+    The default test policy allows direct egress ("direct") over https
+    so that individual rules can be tested in isolation.
+    """
+    defaults = {
+        "proxy": "direct",
+        "schemes": ("https",),
+        "content_types": ("application/pdf",),
+        "max_bytes": 1024,
+        "timeout": 5.0,
+        "max_redirects": 3,
+        "allow_ip_hosts": False,
+    }
+    defaults.update(overrides)
+    return UrlFetchPolicy(**defaults)
+
+
+class TestIsBlockedIp:
+    """Tests for the blocked-IP range tables."""
+
+    @pytest.mark.parametrize(
+        ("address",),
+        [
+            ("0.0.0.0",),
+            ("10.0.0.1",),
+            ("10.255.255.255",),
+            ("127.0.0.1",),
+            ("127.255.0.1",),
+            ("169.254.169.254",),  # cloud metadata
+            ("172.16.0.1",),
+            ("172.31.255.255",),
+            ("192.168.1.1",),
+            ("100.64.0.1",),
+            ("100.127.255.255",),
+            ("192.0.0.8",),
+            ("192.0.2.44",),
+            ("198.18.0.1",),
+            ("198.51.100.23",),
+            ("203.0.113.7",),
+            ("224.0.0.1",),
+            ("239.255.255.255",),
+            ("240.0.0.1",),
+            ("254.255.255.255",),
+            ("255.255.255.255",),
+        ],
+    )
+    def test_blocked_ipv4(self, address: str):
+        """Every documented private/reserved IPv4 range is blocked."""
+        assert is_blocked_ip(ipaddress.IPv4Address(address)) is True
+
+    @pytest.mark.parametrize(
+        ("address",),
+        [
+            ("::",),
+            ("::1",),
+            ("::ffff:127.0.0.1",),  # IPv4-mapped loopback
+            ("::ffff:10.0.0.1",),  # IPv4-mapped private
+            ("::ffff:169.254.169.254",),  # IPv4-mapped metadata
+            ("64:ff9b::1",),
+            ("100::1",),
+            ("fc00::1",),
+            ("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",),
+            ("fe80::1",),
+            ("ff02::1",),
+            ("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",),
+        ],
+    )
+    def test_blocked_ipv6(self, address: str):
+        """Every documented private/reserved IPv6 range is blocked."""
+        assert is_blocked_ip(ipaddress.IPv6Address(address)) is True
+
+    @pytest.mark.parametrize(
+        ("address",),
+        [
+            ("8.8.8.8",),
+            ("1.1.1.1",),
+            ("93.184.216.34",),
+            ("172.32.0.1",),  # just outside 172.16/12
+            ("100.128.0.1",),  # just outside CGNAT
+            ("223.255.255.255",),  # just below multicast
+            ("2a00:1450::1",),
+            ("2606:4700:4700::1111",),
+        ],
+    )
+    def test_public_addresses_allowed(self, address: str):
+        """Public addresses are not blocked."""
+        assert is_blocked_ip(ipaddress.ip_address(address)) is False
+
+
+class TestIsIpLiteral:
+    """Tests for IP-literal hostname detection."""
+
+    @pytest.mark.parametrize(
+        ("host",),
+        [
+            ("127.0.0.1",),
+            ("8.8.8.8",),
+            ("::1",),
+            ("2001:db8::1",),
+            ("[::1]",),
+            ("[2001:db8::1]",),
+            ("2130706433",),  # all-numeric (decimal IP obfuscation)
+            ("1234",),
+        ],
+    )
+    def test_literals_detected(self, host: str):
+        """Standard and obfuscated IP literals are detected."""
+        assert is_ip_literal(host) is True
+
+    @pytest.mark.parametrize(
+        ["host"],
+        [
+            ["example.com"],
+            ["sub.domain.example.org"],
+            ["localhost"],
+            ["123abc"],
+            [""],
+            ["   "],
+        ],
+    )
+    def test_non_literals(self, host: str):
+        """Ordinary hostnames are not IP literals."""
+        assert is_ip_literal(host) is False
+
+
+class TestParseIpHost:
+    """Tests for parse_ip_host."""
+
+    def test_ipv4(self):
+        """A plain IPv4 host parses to an IPv4Address."""
+        assert parse_ip_host("127.0.0.1") == ipaddress.IPv4Address("127.0.0.1")
+
+    def test_bracketed_ipv6(self):
+        """Bracketed IPv6 (URL form) is unwrapped."""
+        assert parse_ip_host("[::1]") == ipaddress.IPv6Address("::1")
+
+    def test_ipv4_mapped_ipv6_is_unwrapped(self):
+        """IPv4-mapped IPv6 addresses normalize to their IPv4 form."""
+        assert parse_ip_host("::ffff:10.0.0.1") == ipaddress.IPv4Address("10.0.0.1")
+
+    def test_non_ip_returns_none(self):
+        """Non-IP hostnames return None."""
+        assert parse_ip_host("example.com") is None
+
+
+class TestValidateUrl:
+    """Tests for validate_url (static, pre-flight URL validation)."""
+
+    def test_refused_when_proxy_not_configured(self):
+        """With no proxy configured, every URL is refused."""
+        policy = make_policy(proxy=None)
+
+        with pytest.raises(ProxyRequiredError):
+            validate_url("https://example.com/paper.pdf", policy)
+
+    def test_proxy_required_is_distinguishable(self):
+        """ProxyRequiredError is a UrlPolicyError but carries its own type."""
+        policy = make_policy(proxy=None)
+
+        with pytest.raises(UrlPolicyError) as exc_info:
+            validate_url("https://example.com/paper.pdf", policy)
+
+        assert isinstance(exc_info.value, ProxyRequiredError)
+        assert "BIBRA_URL_PROXY" in str(exc_info.value)
+
+    def test_https_url_accepted(self):
+        """A well-formed https URL with a hostname passes."""
+        policy = make_policy()
+
+        assert validate_url("https://example.com/paper.pdf", policy) is None
+
+    def test_scheme_not_allowed(self):
+        """Schemes outside the allowlist are rejected."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError, match="fetch policy"):
+            validate_url("http://example.com/paper.pdf", policy)
+
+    def test_scheme_allowlist_extended(self):
+        """Adding http to the allowlist permits it."""
+        policy = make_policy(schemes=("https", "http"))
+
+        assert validate_url("http://example.com/paper.pdf", policy) is None
+
+    def test_scheme_is_case_insensitive(self):
+        """Scheme matching is case-insensitive."""
+        policy = make_policy()
+
+        assert validate_url("HTTPS://example.com/paper.pdf", policy) is None
+
+    def test_url_without_host_rejected(self):
+        """A URL with no hostname is rejected."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https:///paper.pdf", policy)
+
+    def test_malformed_url_rejected(self):
+        """An unparseable URL is rejected (no exception leaks)."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://example.com:badport/x", policy)
+
+    @pytest.mark.parametrize(
+        ("url",),
+        [
+            ("https://127.0.0.1/paper.pdf",),
+            ("https://169.254.169.254/latest/meta-data/",),
+            ("https://10.0.0.5/internal",),
+            ("https://192.168.1.1/router",),
+            ("https://[::1]/paper.pdf",),
+            ("https://[::ffff:127.0.0.1]/paper.pdf",),
+        ],
+    )
+    def test_blocked_ip_literals_rejected(self, url: str):
+        """IP literals in blocked ranges are always rejected."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url(url, policy)
+
+    def test_public_ip_literal_rejected_by_default(self):
+        """Even public IP literals are rejected unless explicitly allowed."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://93.184.216.34/paper.pdf", policy)
+
+    def test_public_ip_literal_allowed_when_configured(self):
+        """BIBRA_URL_ALLOW_IP_HOSTS semantics: public literals then pass."""
+        policy = make_policy(allow_ip_hosts=True)
+
+        assert validate_url("https://93.184.216.34/paper.pdf", policy) is None
+
+    def test_numeric_hostname_rejected(self):
+        """All-numeric hostnames (decimal IP obfuscation) are rejected."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://2130706433/paper.pdf", policy)
+
+    def test_error_messages_are_generic(self):
+        """Rejection messages never leak the offending URL."""
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError) as exc_info:
+            validate_url("http://example.com/secret.pdf", policy)
+
+        assert "example.com" not in str(exc_info.value)
+        assert "secret.pdf" not in str(exc_info.value)
+
+
+class TestIsPdf:
+    """Tests for the PDF content validator."""
+
+    def test_valid_pdf_header(self):
+        """A standard PDF header is recognized."""
+        assert is_pdf(b"%PDF-1.7\n%blah\n...") is True
+
+    def test_pdf_with_leading_whitespace(self):
+        """Leading whitespace before the magic bytes is tolerated."""
+        assert is_pdf(b"  \t\r\n%PDF-1.4\n") is True
+
+    def test_pdf_with_utf8_bom(self):
+        """A UTF-8 BOM before the magic bytes is tolerated."""
+        assert is_pdf(b"\xef\xbb\xbf%PDF-1.5\n") is True
+
+    @pytest.mark.parametrize(
+        ["data"],
+        [
+            [b"PK\x03\x04"],  # zip
+            [b"\x89PNG\r\n\x1a\n"],  # png
+            [b"<html>not a pdf</html>"],
+            [b""],
+            [b"\x00" * 2048],
+        ],
+    )
+    def test_non_pdf_rejected(self, data: bytes):
+        """Non-PDF content is rejected."""
+        assert is_pdf(data) is False
+
+    def test_magic_bytes_beyond_search_window(self):
+        """%PDF beyond the 1024-byte search window is not recognized."""
+        data = b"x" * 1024 + b"%PDF-1.7"
+
+        assert is_pdf(data) is False
+
+    def test_magic_bytes_within_search_window(self):
+        """%PDF fully within the 1024-byte window is recognized."""
+        data = b"x" * 1010 + b"%PDF-1.7"
+
+        assert is_pdf(data) is True
+
+
+class TestContentValidatorProtocol:
+    """Tests that validators plug into the ContentValidator protocol."""
+
+    def test_is_pdf_satisfies_protocol(self):
+        """is_pdf is structurally compatible with ContentValidator."""
+        validator: ContentValidator = is_pdf
+
+        assert validator(b"%PDF-1.7") is True
+
+    def test_custom_validator(self):
+        """A custom validator (e.g. for a future file type) can be passed."""
+
+        def is_png(data: bytes) -> bool:
+            return data.startswith(b"\x89PNG")
+
+        validator: ContentValidator = is_png
+
+        assert validator(b"\x89PNG\r\n\x1a\n") is True
+        assert validator(b"%PDF-1.7") is False
+
+
+class TestPolicyIntegration:
+    """End-to-end tests combining load_url_fetch_policy with validate_url."""
+
+    def test_default_policy_refuses_fetches(self, monkeypatch):
+        """With no env vars set, validation refuses everything (503 case)."""
+        for var in (
+            "BIBRA_URL_PROXY",
+            "BIBRA_URL_SCHEMES",
+            "BIBRA_URL_CONTENT_TYPES",
+            "BIBRA_URL_MAX_BYTES",
+            "BIBRA_URL_TIMEOUT",
+            "BIBRA_URL_MAX_REDIRECTS",
+            "BIBRA_URL_ALLOW_IP_HOSTS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        policy = load_url_fetch_policy()
+
+        with pytest.raises(ProxyRequiredError):
+            validate_url("https://example.com/paper.pdf", policy)
+
+    def test_direct_mode_allows_public_hostname(self, monkeypatch):
+        """BIBRA_URL_PROXY=direct enables fetches of public https hosts."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "direct")
+
+        policy = load_url_fetch_policy()
+
+        assert validate_url("https://example.com/paper.pdf", policy) is None
+
+    def test_proxy_url_mode_allows_public_hostname(self, monkeypatch):
+        """A configured proxy URL enables fetches of public https hosts."""
+        monkeypatch.setenv("BIBRA_URL_PROXY", "http://proxy.example.com:8080")
+
+        policy = load_url_fetch_policy()
+
+        assert validate_url("https://example.com/paper.pdf", policy) is None

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -265,6 +265,18 @@ class TestValidateUrl:
         with pytest.raises(UrlPolicyError):
             validate_url("https://2130706433/paper.pdf", policy)
 
+    def test_unparseable_numeric_hostname_rejected(self):
+        """A numeric hostname that is not a valid IPv4 literal is rejected.
+
+        4294967296 == 2**32 is just above the IPv4 address space, so
+        ipaddress.ip_address() cannot parse it; the is_ip_literal gate
+        still classifies it as an IP literal and rejects it.
+        """
+        policy = make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            validate_url("https://4294967296/paper.pdf", policy)
+
     def test_error_messages_are_generic(self):
         """Rejection messages never leak the offending URL."""
         policy = make_policy()

--- a/tests/test_net_security.py
+++ b/tests/test_net_security.py
@@ -8,14 +8,15 @@ import ipaddress
 
 import pytest
 
-from bibra.config import UrlFetchPolicy, load_url_fetch_policy
 from bibra.net_security import (
     ContentValidator,
     ProxyRequiredError,
+    UrlFetchPolicy,
     UrlPolicyError,
     is_blocked_ip,
     is_ip_literal,
     is_pdf,
+    load_url_fetch_policy,
     parse_ip_host,
     validate_url,
 )

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -563,26 +563,3 @@ class TestProxyModeDnsCheck:
 
         assert data == PDF_BODY
         assert len(calls) >= 1, "direct mode skipped the resolved-IP check"
-
-
-class TestFetchFileSync:
-    """The sync wrapper must work outside an event loop (CLI path)."""
-
-    def test_success(self, pdf_server, monkeypatch):
-        """fetch_file_sync returns the body for a valid PDF."""
-
-        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
-
-        data = ns.fetch_file_sync(
-            f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy()
-        )
-
-        assert data == PDF_BODY
-        assert ns.is_pdf(data)
-
-    def test_policy_error_propagates(self, pdf_server):
-        """Policy violations propagate through the sync wrapper."""
-        with pytest.raises(ns.UrlPolicyError):
-            ns.fetch_file_sync(
-                f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy()
-            )

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -10,6 +10,7 @@ mitigations end-to-end:
     - per-hop policy re-application (redirects to a disallowed scheme or
       to an IP literal with allow_ip_hosts=False are refused on the hop)
     - hard size-cap enforcement (Content-Length pre-check and mid-stream)
+    - total download deadline (a drip-feeding server is still aborted)
     - content-type allowlist and magic-byte verification
     - proxy-required refusal
 
@@ -24,6 +25,7 @@ import http.server
 import socket
 import socketserver
 import threading
+import time
 
 import httpx2
 import pytest
@@ -363,6 +365,53 @@ class TestSizeCap:
         )
 
         assert data == PDF_BODY
+
+
+class TestTotalDeadline:
+    """The total download deadline must bound even a drip-feeding server."""
+
+    def test_drip_feed_exceeds_total_deadline(self, monkeypatch):
+        """A server that sends a byte every 0.2s (each read well under the
+        per-read timeout) is aborted once the total deadline elapses.
+
+        Without the total deadline, this fetch would run for the full
+        ~10s of dripped data, since no single read ever times out.
+        """
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Drip(_Handler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/pdf")
+                self.end_headers()
+                for _ in range(50):
+                    self.wfile.write(b"%")
+                    self.wfile.flush()
+                    time.sleep(0.2)
+
+        srv, port = _start_server(Drip)
+        try:
+            start = time.monotonic()
+            with pytest.raises(httpx2.ReadTimeout) as exc_info:
+                asyncio.run(
+                    ns.fetch_file(
+                        f"http://127.0.0.1:{port}/drip.pdf",
+                        _make_policy(timeout=1.5),
+                    )
+                )
+            elapsed = time.monotonic() - start
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+        # ReadTimeout is an httpx2.HTTPError (caught by the API 502
+        # handler and the CLI's network-error branch) and NOT a
+        # UrlPolicyError.
+        assert isinstance(exc_info.value, httpx2.HTTPError)
+        assert not isinstance(exc_info.value, ns.UrlPolicyError)
+        # Aborted near the 1.5s total deadline, not after the ~10s of
+        # available data (generous upper bound keeps this flake-free).
+        assert elapsed < 5.0
 
 
 class TestContentValidation:

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -21,6 +21,7 @@ blocking use the real, unpatched check.
 
 import asyncio
 import http.server
+import socket
 import socketserver
 import threading
 
@@ -400,6 +401,74 @@ class TestProxyRequired:
 
         with pytest.raises(ns.ProxyRequiredError):
             asyncio.run(ns.fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
+
+
+class TestAmbientProxyEnvIgnored:
+    """Ambient HTTP(S)_PROXY env vars must not hijack egress.
+
+    The transport is built with trust_env=False, so the only egress route
+    in effect is the policy's explicit BIBRA_URL_PROXY (if any).
+    """
+
+    @staticmethod
+    def _start_recording_proxy() -> tuple[socket.socket, int, list]:
+        """A socket that accepts (and closes) connections, recording them."""
+        sock = socket.socket()
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(5)
+        port = sock.getsockname()[1]
+        connections: list = []
+
+        def _accept_loop():
+            while True:
+                try:
+                    conn, addr = sock.accept()
+                except OSError:
+                    return
+                connections.append(addr)
+                conn.close()
+
+        threading.Thread(target=_accept_loop, daemon=True).start()
+        return sock, port, connections
+
+    def test_direct_mode_ignores_ambient_proxy(self, pdf_server, monkeypatch):
+        """With HTTP_PROXY/HTTPS_PROXY set, direct mode still goes direct."""
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+        sock, port, connections = self._start_recording_proxy()
+        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{port}")
+        monkeypatch.setenv("HTTPS_PROXY", f"http://127.0.0.1:{port}")
+        try:
+            data = asyncio.run(
+                ns.fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", _make_policy())
+            )
+        finally:
+            sock.close()
+
+        assert data == PDF_BODY
+        assert connections == [], "direct mode leaked egress to ambient proxy"
+
+    def test_explicit_proxy_still_used(self, pdf_server, monkeypatch):
+        """An explicitly configured proxy is still routed through."""
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+        sock, port, connections = self._start_recording_proxy()
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        try:
+            # The recording proxy closes the connection, so the fetch fails
+            # at the protocol level — but the connection attempt itself
+            # proves the explicit proxy is in effect.
+            with pytest.raises(httpx2.HTTPError):
+                asyncio.run(
+                    ns.fetch_file(
+                        f"http://127.0.0.1:{pdf_server}/x.pdf",
+                        _make_policy(proxy=f"http://127.0.0.1:{port}"),
+                    )
+                )
+        finally:
+            sock.close()
+
+        assert len(connections) >= 1, "explicit proxy was not used"
 
 
 class TestFetchFileSync:

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -29,13 +29,12 @@ import httpx2
 import pytest
 
 import bibra.net_security as ns
-from bibra.net_security import UrlFetchPolicy
 
 PDF_BODY = b"%PDF-1.7\n% fake pdf content\n%%EOF\n"
 METADATA_IP = "169.254.169.254"
 
 
-def _make_policy(**overrides) -> UrlFetchPolicy:
+def _make_policy(**overrides) -> ns.UrlFetchPolicy:
     """Build a policy that allows http to localhost for these tests."""
     defaults = {
         "proxy": "direct",
@@ -47,7 +46,7 @@ def _make_policy(**overrides) -> UrlFetchPolicy:
         "allow_ip_hosts": True,
     }
     defaults.update(overrides)
-    return UrlFetchPolicy(**defaults)
+    return ns.UrlFetchPolicy(**defaults)
 
 
 class _Handler(http.server.BaseHTTPRequestHandler):

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -428,7 +428,7 @@ class TestContentValidation:
 
         srv, port = _start_server(Handler)
         try:
-            with pytest.raises(ns.UrlPolicyError):
+            with pytest.raises(ns.UnsupportedContentTypeError):
                 asyncio.run(ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
         finally:
             srv.shutdown()
@@ -465,7 +465,7 @@ class TestContentValidation:
 
         srv, port = _start_server(Handler)
         try:
-            with pytest.raises(ns.UrlPolicyError):
+            with pytest.raises(ns.UnsupportedContentTypeError):
                 asyncio.run(ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
         finally:
             srv.shutdown()

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -83,6 +83,32 @@ def _start_server(handler_cls) -> tuple[socketserver.TCPServer, int]:
     return srv, srv.server_address[1]
 
 
+def _start_recording_proxy() -> tuple[socket.socket, int, list]:
+    """A socket that accepts (and closes) connections, recording them.
+
+    Acts as a dummy forward proxy for tests: any connection made to it is
+    evidence that egress was routed through it.
+    """
+    sock = socket.socket()
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(5)
+    port = sock.getsockname()[1]
+    connections: list = []
+
+    def _accept_loop():
+        while True:
+            try:
+                conn, addr = sock.accept()
+            except OSError:
+                return
+            connections.append(addr)
+            conn.close()
+
+    threading.Thread(target=_accept_loop, daemon=True).start()
+    return sock, port, connections
+
+
 @pytest.fixture
 def pdf_server():
     """A local server that serves a valid PDF body."""
@@ -435,32 +461,10 @@ class TestAmbientProxyEnvIgnored:
     in effect is the policy's explicit BIBRA_URL_PROXY (if any).
     """
 
-    @staticmethod
-    def _start_recording_proxy() -> tuple[socket.socket, int, list]:
-        """A socket that accepts (and closes) connections, recording them."""
-        sock = socket.socket()
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(("127.0.0.1", 0))
-        sock.listen(5)
-        port = sock.getsockname()[1]
-        connections: list = []
-
-        def _accept_loop():
-            while True:
-                try:
-                    conn, addr = sock.accept()
-                except OSError:
-                    return
-                connections.append(addr)
-                conn.close()
-
-        threading.Thread(target=_accept_loop, daemon=True).start()
-        return sock, port, connections
-
     def test_direct_mode_ignores_ambient_proxy(self, pdf_server, monkeypatch):
         """With HTTP_PROXY/HTTPS_PROXY set, direct mode still goes direct."""
         monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
-        sock, port, connections = self._start_recording_proxy()
+        sock, port, connections = _start_recording_proxy()
         monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{port}")
         monkeypatch.setenv("HTTPS_PROXY", f"http://127.0.0.1:{port}")
         try:
@@ -476,7 +480,7 @@ class TestAmbientProxyEnvIgnored:
     def test_explicit_proxy_still_used(self, pdf_server, monkeypatch):
         """An explicitly configured proxy is still routed through."""
         monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
-        sock, port, connections = self._start_recording_proxy()
+        sock, port, connections = _start_recording_proxy()
         monkeypatch.delenv("HTTP_PROXY", raising=False)
         monkeypatch.delenv("HTTPS_PROXY", raising=False)
         try:
@@ -494,6 +498,71 @@ class TestAmbientProxyEnvIgnored:
             sock.close()
 
         assert len(connections) >= 1, "explicit proxy was not used"
+
+
+class TestProxyModeDnsCheck:
+    """The connect-time resolved-IP check applies in direct mode only.
+
+    In proxy mode the proxy's own egress allowlist is the authoritative
+    control; a local getaddrinfo of the target is skipped (no false
+    positives from resolver differences, no unexpected local DNS lookup).
+    """
+
+    def test_proxy_mode_skips_local_dns_check(self, monkeypatch):
+        """In proxy mode no local getaddrinfo of the target is performed."""
+        calls = []
+
+        def _boom(*args, **kwargs):
+            calls.append(args)
+            raise socket.gaierror("must not be called in proxy mode")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _boom)
+        sock, port, _ = _start_recording_proxy()
+        try:
+            # The dummy proxy closes the connection, so the fetch fails at
+            # the protocol level — but it must get there without a local
+            # DNS lookup of the target (no UrlPolicyError / ConnectError
+            # from our check, only the proxy's protocol failure).
+            with pytest.raises(httpx2.HTTPError) as exc_info:
+                asyncio.run(
+                    ns.fetch_file(
+                        "http://some-unresolvable-host.invalid/x.pdf",
+                        _make_policy(proxy=f"http://127.0.0.1:{port}"),
+                    )
+                )
+        finally:
+            sock.close()
+
+        assert calls == [], "proxy mode performed a local DNS lookup"
+        assert not isinstance(exc_info.value, ns.UrlPolicyError)
+
+    def test_direct_mode_still_runs_dns_check(self, monkeypatch):
+        """In direct mode the resolved-IP check still runs (via getaddrinfo)."""
+        calls = []
+        real = socket.getaddrinfo
+
+        def _counting(*args, **kwargs):
+            calls.append(args)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(socket, "getaddrinfo", _counting)
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Handler(_Handler):
+            def do_GET(self):
+                self._send(PDF_BODY)
+
+        srv, port = _start_server(Handler)
+        try:
+            data = asyncio.run(
+                ns.fetch_file(f"http://localhost:{port}/x.pdf", _make_policy())
+            )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+        assert data == PDF_BODY
+        assert len(calls) >= 1, "direct mode skipped the resolved-IP check"
 
 
 class TestFetchFileSync:

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -97,6 +97,31 @@ def pdf_server():
     srv.server_close()
 
 
+class TestDnsFailure:
+    """A hostname that does not resolve is a download failure, not a
+    policy rejection (no UrlPolicyError)."""
+
+    def test_unresolvable_host_raises_connect_error(self, monkeypatch):
+        """socket.gaierror surfaces as httpx2.ConnectError (a httpx2.HTTPError)."""
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: (_ for _ in ()).throw(socket.gaierror("name not resolved")),
+        )
+
+        # ConnectError is the specific type; it is also an httpx2.HTTPError
+        # (so the API's 502 handler catches it) and NOT a UrlPolicyError.
+        with pytest.raises(httpx2.ConnectError) as exc_info:
+            asyncio.run(
+                ns.fetch_file("http://nonexistent-host.invalid/x.pdf", _make_policy())
+            )
+
+        assert isinstance(exc_info.value, httpx2.HTTPError)
+        assert not isinstance(exc_info.value, ns.UrlPolicyError)
+        # No internal details (hostname) leak into the client-facing message.
+        assert "nonexistent-host.invalid" not in str(exc_info.value)
+
+
 class TestConnectTimeBlocking:
     """The resolved destination IP must be blocked at connect time."""
 

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -29,7 +29,7 @@ import httpx2
 import pytest
 
 import bibra.net_security as ns
-from bibra.config import UrlFetchPolicy
+from bibra.net_security import UrlFetchPolicy
 
 PDF_BODY = b"%PDF-1.7\n% fake pdf content\n%%EOF\n"
 METADATA_IP = "169.254.169.254"

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -1,0 +1,375 @@
+"""Integration tests for the fetch layer in bibra/net_security.py.
+
+These tests spin up real HTTP servers bound to 127.0.0.1 to prove the SSRF
+mitigations end-to-end:
+
+    - connect-time resolved-IP blocking (loopback literals and the
+      localhost hostname are refused without any patching)
+    - redirect-hijack refusal (a reachable host 302-redirecting to the
+      cloud-metadata address is refused on the hop)
+    - hard size-cap enforcement (Content-Length pre-check and mid-stream)
+    - content-type allowlist and magic-byte verification
+    - proxy-required refusal
+
+Because the loopback range is blocked by design, tests that need a
+*successful* fetch from the local test server monkeypatch
+``net_security.is_blocked_ip`` to allow the connection. Tests that assert
+blocking use the real, unpatched check.
+"""
+
+import asyncio
+import http.server
+import socketserver
+import threading
+
+import httpx2
+import pytest
+
+import bibra.net_security as ns
+from bibra.config import UrlFetchPolicy
+from bibra.net_security import (
+    DownloadSizeExceededError,
+    ProxyRequiredError,
+    UrlPolicyError,
+    fetch_file,
+    fetch_file_sync,
+    is_pdf,
+)
+
+PDF_BODY = b"%PDF-1.7\n% fake pdf content\n%%EOF\n"
+METADATA_IP = "169.254.169.254"
+
+
+def _make_policy(**overrides) -> UrlFetchPolicy:
+    """Build a policy that allows http to localhost for these tests."""
+    defaults = {
+        "proxy": "direct",
+        "schemes": ("http",),
+        "content_types": ("application/pdf",),
+        "max_bytes": 1024 * 1024,
+        "timeout": 5.0,
+        "max_redirects": 3,
+        "allow_ip_hosts": True,
+    }
+    defaults.update(overrides)
+    return UrlFetchPolicy(**defaults)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    """Base handler; subclasses override do_GET."""
+
+    def log_message(self, *args):
+        pass
+
+    def _send(self, body: bytes, content_type: str = "application/pdf"):
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _RedirectHandler(_Handler):
+    """302-redirect every request to a class-level Location."""
+
+    location: str = ""
+
+    def do_GET(self):
+        self.send_response(302)
+        self.send_header("Location", self.location)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def _start_server(handler_cls) -> tuple[socketserver.TCPServer, int]:
+    """Start a TCPServer on 127.0.0.1 with a free port; return (srv, port)."""
+    srv = socketserver.TCPServer(("127.0.0.1", 0), handler_cls)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+@pytest.fixture
+def pdf_server():
+    """A local server that serves a valid PDF body."""
+
+    class Handler(_Handler):
+        def do_GET(self):
+            self._send(PDF_BODY)
+
+    srv, port = _start_server(Handler)
+    yield port
+    srv.shutdown()
+    srv.server_close()
+
+
+class TestConnectTimeBlocking:
+    """The resolved destination IP must be blocked at connect time."""
+
+    def test_ip_literal_loopback_refused(self, pdf_server):
+        """A loopback IP literal is refused (real, unpatched check)."""
+        policy = _make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            asyncio.run(fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
+
+    def test_localhost_hostname_refused(self, pdf_server):
+        """http://localhost resolves to loopback and is refused.
+
+        Exercises the async DNS-resolution path (loop.getaddrinfo) with a
+        real hostname, no patching.
+        """
+        policy = _make_policy(allow_ip_hosts=False)
+
+        with pytest.raises(UrlPolicyError):
+            asyncio.run(fetch_file(f"http://localhost:{pdf_server}/x.pdf", policy))
+
+    def test_metadata_ip_literal_refused(self, pdf_server):
+        """The cloud-metadata IP is refused even in proxy-required bypass."""
+        policy = _make_policy()
+
+        with pytest.raises(UrlPolicyError):
+            asyncio.run(fetch_file(f"http://{METADATA_IP}/latest/meta-data/", policy))
+
+
+class TestRedirectRevalidation:
+    """Redirect hops must pass the same destination check."""
+
+    def test_public_to_public_redirect_ok(self, pdf_server, monkeypatch):
+        """A redirect between reachable hosts is followed successfully."""
+
+        # Allow loopback so both hops can connect; we assert the redirect
+        # was followed and the final body returned.
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Redir(_RedirectHandler):
+            location = f"http://127.0.0.1:{pdf_server}/final.pdf"
+
+        srv, port = _start_server(Redir)
+        try:
+            data = asyncio.run(
+                fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
+            )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+        assert data == PDF_BODY
+
+    def test_redirect_to_metadata_refused_on_hop(self, monkeypatch):
+        """A reachable host that 302s to the metadata IP is refused.
+
+        The initial hop (127.0.0.1) is allowed by the patched check, so the
+        UrlPolicyError can only come from the redirect target being
+        re-validated at connect time.
+        """
+
+        def blocked(ip):
+            return str(ip) == METADATA_IP
+
+        monkeypatch.setattr(ns, "is_blocked_ip", blocked)
+
+        class Redir(_RedirectHandler):
+            location = f"http://{METADATA_IP}/latest/meta-data/"
+
+        srv, port = _start_server(Redir)
+        try:
+            with pytest.raises(UrlPolicyError):
+                asyncio.run(
+                    fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_too_many_redirects(self, monkeypatch):
+        """Exceeding max_redirects raises instead of looping forever."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Redir(_RedirectHandler):
+            location = "/loop"
+
+        srv, port = _start_server(Redir)
+        try:
+            with pytest.raises(httpx2.TooManyRedirects):
+                asyncio.run(
+                    fetch_file(
+                        f"http://127.0.0.1:{port}/loop",
+                        _make_policy(max_redirects=2),
+                    )
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+
+class TestSizeCap:
+    """The hard byte cap must be enforced."""
+
+    def test_content_length_precheck(self, monkeypatch):
+        """A Content-Length above the cap aborts before reading the body."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Big(_Handler):
+            def do_GET(self):
+                self._send(b"%PDF-1.7\n" + b"x" * (5 * 1024 * 1024))
+
+        srv, port = _start_server(Big)
+        try:
+            with pytest.raises(DownloadSizeExceededError):
+                asyncio.run(
+                    fetch_file(
+                        f"http://127.0.0.1:{port}/big.pdf",
+                        _make_policy(max_bytes=1024),
+                    )
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_mid_stream_abort(self, monkeypatch):
+        """Without a Content-Length, the cap aborts mid-stream."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class NoLength(_Handler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/pdf")
+                self.end_headers()
+                self.wfile.write(b"%PDF-1.7\n" + b"x" * (2 * 1024 * 1024))
+
+        srv, port = _start_server(NoLength)
+        try:
+            with pytest.raises(DownloadSizeExceededError):
+                asyncio.run(
+                    fetch_file(
+                        f"http://127.0.0.1:{port}/big.pdf",
+                        _make_policy(max_bytes=4096),
+                    )
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_within_cap_succeeds(self, pdf_server, monkeypatch):
+        """A body under the cap is returned in full."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        data = asyncio.run(
+            fetch_file(
+                f"http://127.0.0.1:{pdf_server}/x.pdf",
+                _make_policy(max_bytes=len(PDF_BODY)),
+            )
+        )
+
+        assert data == PDF_BODY
+
+
+class TestContentValidation:
+    """Content-type and magic-byte checks must reject non-PDF bodies."""
+
+    def test_wrong_content_type_refused(self, monkeypatch):
+        """A non-PDF Content-Type is refused even for PDF-like bytes."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Handler(_Handler):
+            def do_GET(self):
+                self._send(PDF_BODY, content_type="text/html")
+
+        srv, port = _start_server(Handler)
+        try:
+            with pytest.raises(UrlPolicyError):
+                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_content_type_with_parameters_accepted(self, pdf_server, monkeypatch):
+        """'application/pdf; charset=...' is accepted (parameters stripped)."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Handler(_Handler):
+            def do_GET(self):
+                self._send(PDF_BODY, content_type="application/pdf; charset=utf-8")
+
+        srv, port = _start_server(Handler)
+        try:
+            data = asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+        assert data == PDF_BODY
+
+    def test_bad_magic_bytes_refused(self, monkeypatch):
+        """PDF Content-Type but non-PDF bytes is refused."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Handler(_Handler):
+            def do_GET(self):
+                self._send(b"this is not a pdf at all")
+
+        srv, port = _start_server(Handler)
+        try:
+            with pytest.raises(UrlPolicyError):
+                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_http_error_status_raises(self, monkeypatch):
+        """A 404 response raises httpx2.HTTPError (not a policy error)."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Handler(_Handler):
+            def do_GET(self):
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        srv, port = _start_server(Handler)
+        try:
+            with pytest.raises(httpx2.HTTPError):
+                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+
+class TestProxyRequired:
+    """URL fetching must be refused when no proxy/direct is configured."""
+
+    def test_refused_when_proxy_unset(self, pdf_server):
+        """proxy=None refuses before any network activity."""
+        policy = _make_policy(proxy=None)
+
+        with pytest.raises(ProxyRequiredError):
+            asyncio.run(fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
+
+
+class TestFetchFileSync:
+    """The sync wrapper must work outside an event loop (CLI path)."""
+
+    def test_success(self, pdf_server, monkeypatch):
+        """fetch_file_sync returns the body for a valid PDF."""
+
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        data = fetch_file_sync(
+            f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy()
+        )
+
+        assert data == PDF_BODY
+        assert is_pdf(data)
+
+    def test_policy_error_propagates(self, pdf_server):
+        """Policy violations propagate through the sync wrapper."""
+        with pytest.raises(UrlPolicyError):
+            fetch_file_sync(f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy())

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -7,6 +7,8 @@ mitigations end-to-end:
       localhost hostname are refused without any patching)
     - redirect-hijack refusal (a reachable host 302-redirecting to the
       cloud-metadata address is refused on the hop)
+    - per-hop policy re-application (redirects to a disallowed scheme or
+      to an IP literal with allow_ip_hosts=False are refused on the hop)
     - hard size-cap enforcement (Content-Length pre-check and mid-stream)
     - content-type allowlist and magic-byte verification
     - proxy-required refusal
@@ -170,6 +172,56 @@ class TestRedirectRevalidation:
             with pytest.raises(ns.UrlPolicyError):
                 asyncio.run(
                     ns.fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_redirect_to_disallowed_scheme_refused_on_hop(self, monkeypatch):
+        """A 302 to a scheme outside the allowlist is refused on the hop.
+
+        Only the per-hop static policy re-check can produce this rejection:
+        the redirect target uses ftp, which is never connectable, so the
+        connect-time IP check is not what blocks it.
+        """
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Redir(_RedirectHandler):
+            location = "ftp://example.invalid/x.pdf"
+
+        srv, port = _start_server(Redir)
+        try:
+            with pytest.raises(ns.UrlPolicyError):
+                asyncio.run(
+                    ns.fetch_file(
+                        f"http://127.0.0.1:{port}/start",
+                        _make_policy(schemes=("http",)),
+                    )
+                )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_redirect_to_ip_literal_refused_when_disallowed(self, monkeypatch):
+        """A 302 to an IP literal is refused when allow_ip_hosts is False.
+
+        The initial URL uses a hostname so it passes the pre-flight check;
+        the redirect target IP is public (range-not-blocked), so only the
+        per-hop re-application of the allow_ip_hosts rule rejects it.
+        """
+        monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
+
+        class Redir(_RedirectHandler):
+            location = "http://93.184.216.34/x.pdf"
+
+        srv, port = _start_server(Redir)
+        try:
+            with pytest.raises(ns.UrlPolicyError):
+                asyncio.run(
+                    ns.fetch_file(
+                        f"http://localhost:{port}/start",
+                        _make_policy(allow_ip_hosts=False),
+                    )
                 )
         finally:
             srv.shutdown()

--- a/tests/test_net_security_fetch.py
+++ b/tests/test_net_security_fetch.py
@@ -27,14 +27,6 @@ import pytest
 
 import bibra.net_security as ns
 from bibra.config import UrlFetchPolicy
-from bibra.net_security import (
-    DownloadSizeExceededError,
-    ProxyRequiredError,
-    UrlPolicyError,
-    fetch_file,
-    fetch_file_sync,
-    is_pdf,
-)
 
 PDF_BODY = b"%PDF-1.7\n% fake pdf content\n%%EOF\n"
 METADATA_IP = "169.254.169.254"
@@ -109,8 +101,8 @@ class TestConnectTimeBlocking:
         """A loopback IP literal is refused (real, unpatched check)."""
         policy = _make_policy()
 
-        with pytest.raises(UrlPolicyError):
-            asyncio.run(fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
+        with pytest.raises(ns.UrlPolicyError):
+            asyncio.run(ns.fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
 
     def test_localhost_hostname_refused(self, pdf_server):
         """http://localhost resolves to loopback and is refused.
@@ -120,15 +112,17 @@ class TestConnectTimeBlocking:
         """
         policy = _make_policy(allow_ip_hosts=False)
 
-        with pytest.raises(UrlPolicyError):
-            asyncio.run(fetch_file(f"http://localhost:{pdf_server}/x.pdf", policy))
+        with pytest.raises(ns.UrlPolicyError):
+            asyncio.run(ns.fetch_file(f"http://localhost:{pdf_server}/x.pdf", policy))
 
     def test_metadata_ip_literal_refused(self, pdf_server):
         """The cloud-metadata IP is refused even in proxy-required bypass."""
         policy = _make_policy()
 
-        with pytest.raises(UrlPolicyError):
-            asyncio.run(fetch_file(f"http://{METADATA_IP}/latest/meta-data/", policy))
+        with pytest.raises(ns.UrlPolicyError):
+            asyncio.run(
+                ns.fetch_file(f"http://{METADATA_IP}/latest/meta-data/", policy)
+            )
 
 
 class TestRedirectRevalidation:
@@ -147,7 +141,7 @@ class TestRedirectRevalidation:
         srv, port = _start_server(Redir)
         try:
             data = asyncio.run(
-                fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
+                ns.fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
             )
         finally:
             srv.shutdown()
@@ -173,9 +167,9 @@ class TestRedirectRevalidation:
 
         srv, port = _start_server(Redir)
         try:
-            with pytest.raises(UrlPolicyError):
+            with pytest.raises(ns.UrlPolicyError):
                 asyncio.run(
-                    fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
+                    ns.fetch_file(f"http://127.0.0.1:{port}/start", _make_policy())
                 )
         finally:
             srv.shutdown()
@@ -193,7 +187,7 @@ class TestRedirectRevalidation:
         try:
             with pytest.raises(httpx2.TooManyRedirects):
                 asyncio.run(
-                    fetch_file(
+                    ns.fetch_file(
                         f"http://127.0.0.1:{port}/loop",
                         _make_policy(max_redirects=2),
                     )
@@ -217,9 +211,9 @@ class TestSizeCap:
 
         srv, port = _start_server(Big)
         try:
-            with pytest.raises(DownloadSizeExceededError):
+            with pytest.raises(ns.DownloadSizeExceededError):
                 asyncio.run(
-                    fetch_file(
+                    ns.fetch_file(
                         f"http://127.0.0.1:{port}/big.pdf",
                         _make_policy(max_bytes=1024),
                     )
@@ -242,9 +236,9 @@ class TestSizeCap:
 
         srv, port = _start_server(NoLength)
         try:
-            with pytest.raises(DownloadSizeExceededError):
+            with pytest.raises(ns.DownloadSizeExceededError):
                 asyncio.run(
-                    fetch_file(
+                    ns.fetch_file(
                         f"http://127.0.0.1:{port}/big.pdf",
                         _make_policy(max_bytes=4096),
                     )
@@ -259,7 +253,7 @@ class TestSizeCap:
         monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
 
         data = asyncio.run(
-            fetch_file(
+            ns.fetch_file(
                 f"http://127.0.0.1:{pdf_server}/x.pdf",
                 _make_policy(max_bytes=len(PDF_BODY)),
             )
@@ -282,8 +276,8 @@ class TestContentValidation:
 
         srv, port = _start_server(Handler)
         try:
-            with pytest.raises(UrlPolicyError):
-                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+            with pytest.raises(ns.UrlPolicyError):
+                asyncio.run(ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
         finally:
             srv.shutdown()
             srv.server_close()
@@ -299,7 +293,9 @@ class TestContentValidation:
 
         srv, port = _start_server(Handler)
         try:
-            data = asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+            data = asyncio.run(
+                ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy())
+            )
         finally:
             srv.shutdown()
             srv.server_close()
@@ -317,8 +313,8 @@ class TestContentValidation:
 
         srv, port = _start_server(Handler)
         try:
-            with pytest.raises(UrlPolicyError):
-                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+            with pytest.raises(ns.UrlPolicyError):
+                asyncio.run(ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
         finally:
             srv.shutdown()
             srv.server_close()
@@ -337,7 +333,7 @@ class TestContentValidation:
         srv, port = _start_server(Handler)
         try:
             with pytest.raises(httpx2.HTTPError):
-                asyncio.run(fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
+                asyncio.run(ns.fetch_file(f"http://127.0.0.1:{port}/x", _make_policy()))
         finally:
             srv.shutdown()
             srv.server_close()
@@ -350,8 +346,8 @@ class TestProxyRequired:
         """proxy=None refuses before any network activity."""
         policy = _make_policy(proxy=None)
 
-        with pytest.raises(ProxyRequiredError):
-            asyncio.run(fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
+        with pytest.raises(ns.ProxyRequiredError):
+            asyncio.run(ns.fetch_file(f"http://127.0.0.1:{pdf_server}/x.pdf", policy))
 
 
 class TestFetchFileSync:
@@ -362,14 +358,16 @@ class TestFetchFileSync:
 
         monkeypatch.setattr(ns, "is_blocked_ip", lambda ip: False)
 
-        data = fetch_file_sync(
+        data = ns.fetch_file_sync(
             f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy()
         )
 
         assert data == PDF_BODY
-        assert is_pdf(data)
+        assert ns.is_pdf(data)
 
     def test_policy_error_propagates(self, pdf_server):
         """Policy violations propagate through the sync wrapper."""
-        with pytest.raises(UrlPolicyError):
-            fetch_file_sync(f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy())
+        with pytest.raises(ns.UrlPolicyError):
+            ns.fetch_file_sync(
+                f"http://127.0.0.1:{pdf_server}/paper.pdf", _make_policy()
+            )

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -61,11 +61,16 @@ def test_api(case):
             case.path = "/v0/projects/dummy/extract-url"
 
         # Mock httpx.AsyncClient stream response
+        mock_response = _mock_httpx_response()
+
+        async def async_get(*args, **kwargs):
+            return mock_response
+
         with patch("httpx.AsyncClient") as mock_client:
             mock_client.__aenter__.return_value = mock_client
             mock_client.__aexit__.return_value = False
-            mock_response = _mock_httpx_response()
             mock_client.stream = MagicMock(return_value=mock_response)
+            mock_client.get = async_get
             with patch("httpx.AsyncClient", return_value=mock_client):
                 case.call_and_validate()
         return

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -8,12 +8,19 @@ from bibra.main import app
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
 
 
-def _mock_pdf_response(*args, **kwargs):
+async def _mock_aiter_bytes(*args, **kwargs):
+    """Async generator that yields mock PDF content."""
+    yield b"%PDF-1.4 mock content"
+
+
+def _mock_httpx_response(*args, **kwargs):
+    """Build a mock httpx stream response for PDF content."""
     mock_response = MagicMock()
-    mock_response.info.return_value.get_content_type.return_value = "application/pdf"
-    mock_response.read.side_effect = [b"%PDF-1.4 mock content", b""]
-    mock_response.__enter__.return_value = mock_response
-    mock_response.__exit__.return_value = False
+    mock_response.headers.get.return_value = "application/pdf"
+    mock_response.status_code = 200
+    mock_response.aiter_bytes.return_value = _mock_aiter_bytes()
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = False
     return mock_response
 
 
@@ -53,9 +60,14 @@ def test_api(case):
             # Modify the path to use dummy project
             case.path = "/v0/projects/dummy/extract-url"
 
-        # Mock pdf file download
-        with patch("urllib.request.urlopen", side_effect=_mock_pdf_response):
-            case.call_and_validate()
+        # Mock httpx.AsyncClient stream response
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = False
+            mock_response = _mock_httpx_response()
+            mock_client.stream = MagicMock(return_value=mock_response)
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                case.call_and_validate()
         return
 
     case.call_and_validate()

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -41,16 +41,16 @@ def test_api(case):
         if hasattr(case, "path") and case.path == "/v0/projects/{project_id}/extract":
             # Modify the path to use dummy project
             case.path = "/v0/projects/dummy/extract"
-    # Skip extract-url cases missing the required `urls` field.
+    # Skip extract-url cases missing the required `url` field.
     is_extract_url = (
         case.path == "/v0/projects/{project_id}/extract-url"
         and case.method.upper() == "POST"
     )
     if is_extract_url:
         body = case.body
-        # Skip if `urls` is absent or empty
-        has_urls = isinstance(body, dict) and bool(body.get("urls"))
-        if not has_urls:
+        # Skip if `url` is absent or empty
+        has_url = isinstance(body, dict) and bool(body.get("url"))
+        if not has_url:
             return
         # Use dummy backend for testing to avoid real network downloads/API calls
         if (

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -1,9 +1,20 @@
+from unittest.mock import MagicMock, patch
+
 import schemathesis
 
 from bibra.main import app
 
 # Load schema directly from FastAPI app
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
+
+
+def _mock_pdf_response(*args, **kwargs):
+    mock_response = MagicMock()
+    mock_response.info.return_value.get_content_type.return_value = "application/pdf"
+    mock_response.read.side_effect = [b"%PDF-1.4 mock content", b""]
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+    return mock_response
 
 
 @schema.parametrize()
@@ -23,4 +34,28 @@ def test_api(case):
         if hasattr(case, "path") and case.path == "/v0/projects/{project_id}/extract":
             # Modify the path to use dummy project
             case.path = "/v0/projects/dummy/extract"
+    # Skip extract-url cases missing the required `urls` field.
+    is_extract_url = (
+        case.path == "/v0/projects/{project_id}/extract-url"
+        and case.method.upper() == "POST"
+    )
+    if is_extract_url:
+        body = case.body
+        # Skip if `urls` is absent or empty
+        has_urls = isinstance(body, dict) and bool(body.get("urls"))
+        if not has_urls:
+            return
+        # Use dummy backend for testing to avoid real network downloads/API calls
+        if (
+            hasattr(case, "path")
+            and case.path == "/v0/projects/{project_id}/extract-url"
+        ):
+            # Modify the path to use dummy project
+            case.path = "/v0/projects/dummy/extract-url"
+
+        # Mock pdf file download
+        with patch("urllib.request.urlopen", side_effect=_mock_pdf_response):
+            case.call_and_validate()
+        return
+
     case.call_and_validate()

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import schemathesis
 
@@ -6,22 +6,6 @@ from bibra.main import app
 
 # Load schema directly from FastAPI app
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
-
-
-async def _mock_aiter_bytes(*args, **kwargs):
-    """Async generator that yields mock PDF content."""
-    yield b"%PDF-1.4 mock content"
-
-
-def _mock_httpx_response(*args, **kwargs):
-    """Build a mock httpx2 stream response for PDF content."""
-    mock_response = MagicMock()
-    mock_response.headers.get.return_value = "application/pdf"
-    mock_response.status_code = 200
-    mock_response.aiter_bytes.return_value = _mock_aiter_bytes()
-    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-    mock_response.__aexit__ = AsyncMock(return_value=False)
-    return mock_response
 
 
 @schema.parametrize()
@@ -52,7 +36,8 @@ def test_api(case):
         has_url = isinstance(body, dict) and bool(body.get("url"))
         if not has_url:
             return
-        # Use dummy backend for testing to avoid real network downloads/API calls
+        # Use dummy backend for testing to avoid real network downloads/API
+        # calls
         if (
             hasattr(case, "path")
             and case.path == "/v0/projects/{project_id}/extract-url"
@@ -60,16 +45,14 @@ def test_api(case):
             # Modify the path to use dummy project
             case.path = "/v0/projects/dummy/extract-url"
 
-        # Mock httpx2.AsyncClient stream response
-        mock_response = _mock_httpx_response()
-
-        with patch("httpx2.AsyncClient") as mock_client:
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            # client.stream() is a sync call returning an async context manager
-            mock_client.stream = MagicMock(return_value=mock_response)
-            with patch("httpx2.AsyncClient", return_value=mock_client):
-                case.call_and_validate()
+        # Mock the hardened fetch layer so no network activity occurs. The
+        # SSRF validation logic itself is covered by dedicated tests in
+        # tests/test_net_security.py and tests/test_net_security_fetch.py.
+        with patch(
+            "bibra.api.v0.routes.fetch_file",
+            new=AsyncMock(return_value=b"%PDF-1.4 mock content"),
+        ):
+            case.call_and_validate()
         return
 
     case.call_and_validate()

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import schemathesis
 
@@ -19,8 +19,8 @@ def _mock_httpx_response(*args, **kwargs):
     mock_response.headers.get.return_value = "application/pdf"
     mock_response.status_code = 200
     mock_response.aiter_bytes.return_value = _mock_aiter_bytes()
-    mock_response.__aenter__.return_value = mock_response
-    mock_response.__aexit__.return_value = False
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
     return mock_response
 
 
@@ -63,14 +63,11 @@ def test_api(case):
         # Mock httpx2.AsyncClient stream response
         mock_response = _mock_httpx_response()
 
-        async def async_get(*args, **kwargs):
-            return mock_response
-
         with patch("httpx2.AsyncClient") as mock_client:
-            mock_client.__aenter__.return_value = mock_client
-            mock_client.__aexit__.return_value = False
-            mock_client.stream = MagicMock(return_value=mock_response)
-            mock_client.get = async_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream = AsyncMock(return_value=mock_response)
+            mock_client.get = AsyncMock(return_value=mock_response)
             with patch("httpx2.AsyncClient", return_value=mock_client):
                 case.call_and_validate()
         return

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -14,7 +14,7 @@ async def _mock_aiter_bytes(*args, **kwargs):
 
 
 def _mock_httpx_response(*args, **kwargs):
-    """Build a mock httpx stream response for PDF content."""
+    """Build a mock httpx2 stream response for PDF content."""
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "application/pdf"
     mock_response.status_code = 200
@@ -60,18 +60,18 @@ def test_api(case):
             # Modify the path to use dummy project
             case.path = "/v0/projects/dummy/extract-url"
 
-        # Mock httpx.AsyncClient stream response
+        # Mock httpx2.AsyncClient stream response
         mock_response = _mock_httpx_response()
 
         async def async_get(*args, **kwargs):
             return mock_response
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("httpx2.AsyncClient") as mock_client:
             mock_client.__aenter__.return_value = mock_client
             mock_client.__aexit__.return_value = False
             mock_client.stream = MagicMock(return_value=mock_response)
             mock_client.get = async_get
-            with patch("httpx.AsyncClient", return_value=mock_client):
+            with patch("httpx2.AsyncClient", return_value=mock_client):
                 case.call_and_validate()
         return
 

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -1,3 +1,5 @@
+"""Schemathesis property-based tests for the API (no real network calls)."""
+
 from unittest.mock import AsyncMock, patch
 
 import schemathesis
@@ -7,44 +9,40 @@ from bibra.main import app
 # Load schema directly from FastAPI app
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
 
+# POST endpoints that need the dummy project to avoid real API calls,
+# keyed by the form field that must be present for the case to be valid.
+_DUMMY_PROJECT_ENDPOINTS = {
+    "/v0/projects/{project_id}/extract": (
+        "/v0/projects/dummy/extract",
+        "files",
+    ),
+    "/v0/projects/{project_id}/extract-url": (
+        "/v0/projects/dummy/extract-url",
+        "url",
+    ),
+}
+
+
+def _prepare(case) -> bool:
+    """Rewrite the project id to "dummy"; return False if the case is invalid."""
+    if case.method.upper() != "POST":
+        return True
+    rewrite = _DUMMY_PROJECT_ENDPOINTS.get(case.path)
+    if rewrite is None:
+        return True
+    dummy_path, required_field = rewrite
+    # Skip bodies missing the required field.
+    if not (isinstance(case.body, dict) and case.body.get(required_field)):
+        return False
+    case.path = dummy_path
+    return True
+
 
 @schema.parametrize()
 def test_api(case):
-    # Skip extract cases missing the required `files` field.
-    is_extract = (
-        case.path == "/v0/projects/{project_id}/extract"
-        and case.method.upper() == "POST"
-    )
-    if is_extract:
-        body = case.body
-        # Skip if `files` is absent or empty
-        has_files = isinstance(body, dict) and bool(body.get("files"))
-        if not has_files:
-            return
-        # Use dummy backend for testing to avoid real API calls
-        if hasattr(case, "path") and case.path == "/v0/projects/{project_id}/extract":
-            # Modify the path to use dummy project
-            case.path = "/v0/projects/dummy/extract"
-    # Skip extract-url cases missing the required `url` field.
-    is_extract_url = (
-        case.path == "/v0/projects/{project_id}/extract-url"
-        and case.method.upper() == "POST"
-    )
-    if is_extract_url:
-        body = case.body
-        # Skip if `url` is absent or empty
-        has_url = isinstance(body, dict) and bool(body.get("url"))
-        if not has_url:
-            return
-        # Use dummy backend for testing to avoid real network downloads/API
-        # calls
-        if (
-            hasattr(case, "path")
-            and case.path == "/v0/projects/{project_id}/extract-url"
-        ):
-            # Modify the path to use dummy project
-            case.path = "/v0/projects/dummy/extract-url"
-
+    if not _prepare(case):
+        return
+    if case.path == "/v0/projects/dummy/extract-url":
         # Mock the hardened fetch layer so no network activity occurs. The
         # SSRF validation logic itself is covered by dedicated tests in
         # tests/test_net_security.py and tests/test_net_security_fetch.py.
@@ -54,5 +52,4 @@ def test_api(case):
         ):
             case.call_and_validate()
         return
-
     case.call_and_validate()

--- a/tests/test_schemathesis.py
+++ b/tests/test_schemathesis.py
@@ -66,8 +66,8 @@ def test_api(case):
         with patch("httpx2.AsyncClient") as mock_client:
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.stream = AsyncMock(return_value=mock_response)
-            mock_client.get = AsyncMock(return_value=mock_response)
+            # client.stream() is a sync call returning an async context manager
+            mock_client.stream = MagicMock(return_value=mock_response)
             with patch("httpx2.AsyncClient", return_value=mock_client):
                 case.call_and_validate()
         return

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "2026-08-06T09:44:44.7887759Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,13 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' or sys_platform != 'emscripten'",
+]
 
 [options]
-exclude-newer = "2026-08-06T09:44:44.7887759Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -53,6 +57,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "fastapi" },
+    { name = "httpx2" },
     { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "pymupdf" },
     { name = "pymupdf4llm" },
@@ -66,7 +71,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "bump-my-version" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -79,6 +84,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = "==0.136.1" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=1.93.0" },
     { name = "pymupdf", specifier = ">=1.27.2" },
     { name = "pymupdf4llm", specifier = ">=1.27.2" },
@@ -92,7 +98,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "bump-my-version", specifier = ">=1.3.0" },
-    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "httpx2", specifier = ">=0.28.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -476,6 +482,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +507,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -539,11 +584,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1958,6 +2003,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "bibra"
-version = "0.1.0.dev0"
+version = "0.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -71,7 +71,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "bump-my-version" },
-    { name = "httpx2" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -98,7 +97,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "bump-my-version", specifier = ">=1.3.0" },
-    { name = "httpx2", specifier = ">=0.28.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Reasons for creating this PR

It is not currently possible to load PDF files from arbitrary URLs in the web UI due to CORS restrictions. This PR adds functionality for loading PDFs to the REST API and CLI.

Because fetching a user-supplied URL server-side is a classic SSRF vector, the feature ships with a hardened fetch layer (defense in depth, see README.md "Security" section) and is **off by default for the REST API**: URL fetching is refused unless `BIBRA_URL_PROXY` is configured to either a HTTP proxy URL or the special keyword `direct`, which explicitly allows direct URL fetching by the backend (but with a lot of security checks).

## Link to relevant issue(s), if any

- Part of #36

## Description of the changes in this PR

**New feature: `extract-url`**
- Add `extract-url` endpoint to the REST API ([`POST /projects/{project_id}/extract-url`](bibra/api/v0/routes.py:124)); returns 400 on policy violation, 502 on download failure, 503 when fetching is not configured
- Add `extract-url` command to the CLI ([`bibra.cli.extract_url`](bibra/cli.py:145)); more lenient egress default than the API — when `BIBRA_URL_PROXY` is unset, the CLI fetches in `direct` mode (still fully validated) instead of refusing
- Add `BaseBackend.extract_from_bytes()` for in-memory PDF extraction via a cleaned-up temp file ([`bibra/backend/base.py`](bibra/backend/base.py))
- Add unit tests for the endpoint, CLI command, backend, and security layer (~1,900 lines of new tests, including new [tests/test_net_security.py](tests/test_net_security.py) and [tests/test_net_security_fetch.py](tests/test_net_security_fetch.py))

**SSRF-hardened fetch layer** — new module [`bibra/net_security.py`](bibra/net_security.py):
- Egress only via explicit `BIBRA_URL_PROXY` (proxy URL or `direct`); unset means "refuse" for the API. `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` are always ignored
- URL and **every redirect hop** are re-validated: scheme allowlist (https only by default), blocked private/loopback/link-local/CGNAT/reserved IPv4+IPv6 ranges, numeric-hostname rejection, redirect cap, timeout, and a hard byte cap enforced mid-stream
- Response `Content-Type` allowlist plus magic-byte verification before bytes are handed to a backend
- Configured via `BIBRA_URL_*` environment variables, documented in [`.env.example`](.env.example)
- Documented in a new "Security" section of the README, including the known DNS-rebinding TOCTOU limitation in `direct` mode

**Refactors & housekeeping**
- New [`bibra/env.py`](bibra/env.py) with generic env-var parsing/interpolation helpers, reused by `config.py`
- Centralized backend resolution and error handling in the API ([`_resolve_backend`](bibra/api/v0/routes.py:42)) and CLI ([`_get_backend`](bibra/cli.py:65))
- Migrate HTTP client from `httpx` (test-only, wasn't actually used, unmaintained but still an indirect dependency via pydantic-ai) to `httpx2>=2.12.0` as a runtime dependency
- Ignore `plans/` directory in `.gitignore` (used for Zoo Code plans)

## Instructions how to test this PR

> Note: URL fetching via the REST API is refused (HTTP 503) unless `BIBRA_URL_PROXY` is set. Either set it to `direct` for local testing or to a proxy URL. The CLI works out of the box.

REST API method can be called with:
```bash
export BIBRA_URL_PROXY=direct
uv run bibra serve --port 8000
# in another shell:
curl -X POST "http://127.0.0.1:8000/v0/projects/greylitlm/extract-url" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "url=https://pdfobject.com/pdf/sample.pdf"
```

CLI method can be called with:
```bash
uv run bibra extract-url greylitlm https://pdfobject.com/pdf/sample.pdf
```

## Known problems or uncertainties in this PR

- In `direct` mode the hostname is resolved once for policy validation and again by the HTTP transport when dialing, leaving a small TOCTOU window that an actively rebinding DNS resolver could exploit. The full protection is provided by routing egress through a proxy (documented in README).

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

## Disclosure of AI Tool Usage
- 🟠 AI:ORANGE	AI-generated at scale. Architecture and design actively co-developed and understood, hot spots reviewed, but not every line checked. Conscious risk of comprehension debt.

Describe the AI tool(s) you used: Zoo Code (with Qwen3.5-35B-A3B and Qwen3.8-27B) for the bulk of the implementation (SSRF fetch layer, endpoint, CLI, tests); Claude Sonnet 5 in chat mode for early unit tests and Gemini-2.5-flash for early CLI and REST code.