### PR TITLE
Allow uv build using uv 0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.15,<0.12"]
+requires = ["uv_build>=0.11.15,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv]


### PR DESCRIPTION
## Reasons for creating this PR

Allow `uv build` with the most recent uv version 0.12, as explained in the [uv 0.12.0 release notes](https://github.com/astral-sh/uv/releases#release-0.12.0).

## Link to relevant issue(s), if any

none

## Description of the changes in this PR

set upper bound for uv as `<0.13` instead of `<0.12`

## Instructions how to test this PR

    uv build

## Known problems or uncertainties in this PR

none

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.
- ⚪ AI:WHITE	Written independently, no significant AI involvement.

