### PR TITLE
Fix inclusion and use of static files in built wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           cache: "npm"
       - name: Install npm dependencies under bibra/node_modules
         run: |
-          npm install --omit=dev
+          npm ci --omit=dev
           mv node_modules bibra/
       - name: Build distributions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  NODE_VERSION: "24"
+
 permissions:
   contents: read
 
@@ -30,6 +33,15 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: ${{ env.PYTHON-VERSION }}
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - name: Install npm dependencies under bibra/node_modules
+        run: |
+          npm install --omit=dev
+          mv node_modules bibra/
       - name: Build distributions
         run: |
           uv build

--- a/bibra/main.py
+++ b/bibra/main.py
@@ -23,8 +23,14 @@ app.mount(
     "/static", StaticFiles(directory=files("bibra").joinpath("static")), name="static"
 )
 
-# Mount node_modules for static files (e.g., Bootstrap) if directory exists
-if os.path.isdir("node_modules"):
+# Mount node_modules for static files (e.g., Bootstrap) if it exists within package...
+if files("bibra").joinpath("node_modules").is_dir():
+    app.mount(
+        "/node_modules",
+        StaticFiles(directory=files("bibra").joinpath("node_modules")),
+        name="node_modules",
+    )
+elif os.path.isdir("node_modules"):  # ...or in the current directory
     app.mount(
         "/node_modules", StaticFiles(directory="node_modules"), name="node_modules"
     )

--- a/bibra/main.py
+++ b/bibra/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from importlib.resources import files
 
 import uvicorn
 from dotenv import load_dotenv
@@ -18,7 +19,9 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="BIBRA API", version=__version__)
 
 # Mount static files at /static path
-app.mount("/static", StaticFiles(directory="bibra/static"), name="static")
+app.mount(
+    "/static", StaticFiles(directory=files("bibra").joinpath("static")), name="static"
+)
 
 # Mount node_modules for static files (e.g., Bootstrap) if directory exists
 if os.path.isdir("node_modules"):
@@ -30,7 +33,7 @@ if os.path.isdir("node_modules"):
 @app.get("/", response_class=HTMLResponse)
 async def root():
     """Return the static index.html page."""
-    return FileResponse("bibra/static/index.html")
+    return FileResponse(files("bibra").joinpath("static/index.html"))
 
 
 app.include_router(v0_router, prefix="/v0")


### PR DESCRIPTION
## Reasons for creating this PR

Package wheels built using `uv build` did not include `node_modules` (e.g. Vue, Bootstrap, Font Awesome) needed by the UI. Also the static assets were loaded in a way that only worked in development but not after installing the wheel. This PR fixes the problems.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* load static assets (`bibra/static` and `node_modules`) via `importlib.resources` so they are resolved to the files within the installed package
* modify the `release.yml` GitHub Actions workflow so it installs Node, runs `npm install` and moves `node_modules` under `bibra` so it gets included into the wheel

## Instructions how to test this PR

Note that for `node_modules` to be included in the wheel by `uv build`, it must be inside the `bibra` package directory, not at the root of the project where it normally gets created by `npm install`. This means that to build a wheel manually, you need to run commands like this:

    npm install --omit=dev
    mv node_modules bibra/
    uv build

The `main.py` code checks for `node_modules` both within the package (`bibra/node_modules`) and directly in the current working directory, so you can still run the app as a developer with `node_modules` at the root of the repository.

## Known problems or uncertainties in this PR

Having two different locations for `node_modules` is a bit ugly, but I couldn't find a more elegant way to do this. `npm install` apparently doesn't support a flag to save dependencies under a different directory than `./node_modules`. I also tried running `cd bibra && npm install` but npm always created `node_modules` in the same directory as `package.json`.

What should work is moving `package.json` under the `bibra` directory and then always running `npm install` there. I have not gone so far in this PR though.

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.
- 🟢 AI:GREEN	AI-assisted. Author drove the process, AI used as a tool (autocomplete, partial generation, refactoring help).

Describe the AI tool(s) you used: Chatting with Qwen3.6-35B-A3B