### PR TITLE
Add CLI command `bibra serve` to start API server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ See the available CLI commands:
 
     uv run bibra
 
-Start up the server:
+Start up the API server and Web UI (add `--reload` for auto-reloading while developing):
 
-    uv run uvicorn bibra.main:app
+    uv run bibra run
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See the available CLI commands:
 
 Start up the API server and Web UI (add `--reload` for auto-reloading while developing):
 
-    uv run bibra run
+    uv run bibra serve
 
 ## Testing
 

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import click
+import uvicorn
 from dotenv import load_dotenv
 
 from bibra.config import (
@@ -103,3 +104,31 @@ def extract(project_id: str, file_path: str, config: str | None, output: str | N
         click.echo(f"Output written to {output}")
     else:
         click.echo(json_output)
+
+
+@cli.command("run")
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    show_default=True,
+    help="Interface address to bind the server to.",
+)
+@click.option(
+    "--port",
+    "-p",
+    default=8000,
+    show_default=True,
+    type=int,
+    help="Port to bind the server to.",
+)
+@click.option(
+    "--reload",
+    is_flag=True,
+    default=False,
+    help="Enable auto-reloading (useful during development).",
+)
+def run(host: str, port: int, reload: bool):
+    """Run the BIBRA API server (FastAPI + Web UI) in the foreground."""
+    # The app is passed as a string import path so that uvicorn's
+    # auto-reloader can import it in a separate worker process.
+    uvicorn.run("bibra.main:app", host=host, port=port, reload=reload)

--- a/bibra/cli.py
+++ b/bibra/cli.py
@@ -106,7 +106,7 @@ def extract(project_id: str, file_path: str, config: str | None, output: str | N
         click.echo(json_output)
 
 
-@cli.command("run")
+@cli.command("serve")
 @click.option(
     "--host",
     default="127.0.0.1",
@@ -127,8 +127,8 @@ def extract(project_id: str, file_path: str, config: str | None, output: str | N
     default=False,
     help="Enable auto-reloading (useful during development).",
 )
-def run(host: str, port: int, reload: bool):
-    """Run the BIBRA API server (FastAPI + Web UI) in the foreground."""
+def serve(host: str, port: int, reload: bool):
+    """Serve the BIBRA API server (FastAPI + Web UI) in the foreground."""
     # The app is passed as a string import path so that uvicorn's
     # auto-reloader can import it in a separate worker process.
     uvicorn.run("bibra.main:app", host=host, port=port, reload=reload)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from bibra.cli import _make_list_template, cli, extract, list_projects
+from bibra.cli import _make_list_template, cli, extract, list_projects, run
 from bibra.config import ConfigError
 
 
@@ -26,6 +26,7 @@ class TestCli:
         assert "BIBRA - Bibliographic metadata extraction tool" in result.output
         assert "list-projects" in result.output
         assert "extract" in result.output
+        assert "run" in result.output
 
     def test_cli_version(self):
         """Test CLI version output."""
@@ -245,6 +246,57 @@ class TestExtract:
             result = self.runner.invoke(extract, ["dummy", str(test_file)])
             assert result.exit_code != 0
             assert "Invalid config syntax" in result.output
+
+
+class TestRun:
+    """Tests for the run command."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+
+    def test_run_help(self):
+        """Test run help output."""
+        result = self.runner.invoke(run, ["--help"])
+        assert result.exit_code == 0
+        assert not result.exception
+        assert "Run the BIBRA API server" in result.output
+        assert "--host" in result.output
+        assert "--port" in result.output
+        assert "-p" in result.output
+        assert "--reload" in result.output
+
+    def test_run_defaults(self):
+        """Test that run calls uvicorn.run with default host and port."""
+        with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
+            result = self.runner.invoke(run)
+            assert result.exit_code == 0
+            assert not result.exception
+            mock_uvicorn_run.assert_called_once_with(
+                "bibra.main:app", host="127.0.0.1", port=8000, reload=False
+            )
+
+    def test_run_with_options(self):
+        """Test that run passes host, port, and reload to uvicorn.run."""
+        with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
+            result = self.runner.invoke(
+                run, ["--host", "0.0.0.0", "--port", "24272", "--reload"]
+            )
+            assert result.exit_code == 0
+            assert not result.exception
+            mock_uvicorn_run.assert_called_once_with(
+                "bibra.main:app", host="0.0.0.0", port=24272, reload=True
+            )
+
+    def test_run_with_short_port_option(self):
+        """Test that run passes the short -p port option to uvicorn.run."""
+        with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
+            result = self.runner.invoke(run, ["-p", "9999"])
+            assert result.exit_code == 0
+            assert not result.exception
+            mock_uvicorn_run.assert_called_once_with(
+                "bibra.main:app", host="127.0.0.1", port=9999, reload=False
+            )
 
 
 class TestMakeListTemplate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from bibra.cli import _make_list_template, cli, extract, list_projects, run
+from bibra.cli import _make_list_template, cli, extract, list_projects, serve
 from bibra.config import ConfigError
 
 
@@ -26,7 +26,7 @@ class TestCli:
         assert "BIBRA - Bibliographic metadata extraction tool" in result.output
         assert "list-projects" in result.output
         assert "extract" in result.output
-        assert "run" in result.output
+        assert "serve" in result.output
 
     def test_cli_version(self):
         """Test CLI version output."""
@@ -248,39 +248,39 @@ class TestExtract:
             assert "Invalid config syntax" in result.output
 
 
-class TestRun:
-    """Tests for the run command."""
+class TestServe:
+    """Tests for the serve command."""
 
     def setup_method(self):
         """Set up test fixtures."""
         self.runner = CliRunner()
 
-    def test_run_help(self):
-        """Test run help output."""
-        result = self.runner.invoke(run, ["--help"])
+    def test_serve_help(self):
+        """Test serve help output."""
+        result = self.runner.invoke(serve, ["--help"])
         assert result.exit_code == 0
         assert not result.exception
-        assert "Run the BIBRA API server" in result.output
+        assert "Serve the BIBRA API server" in result.output
         assert "--host" in result.output
         assert "--port" in result.output
         assert "-p" in result.output
         assert "--reload" in result.output
 
-    def test_run_defaults(self):
-        """Test that run calls uvicorn.run with default host and port."""
+    def test_serve_defaults(self):
+        """Test that serve calls uvicorn.run with default host and port."""
         with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
-            result = self.runner.invoke(run)
+            result = self.runner.invoke(serve)
             assert result.exit_code == 0
             assert not result.exception
             mock_uvicorn_run.assert_called_once_with(
                 "bibra.main:app", host="127.0.0.1", port=8000, reload=False
             )
 
-    def test_run_with_options(self):
-        """Test that run passes host, port, and reload to uvicorn.run."""
+    def test_serve_with_options(self):
+        """Test that serve passes host, port, and reload to uvicorn.run."""
         with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
             result = self.runner.invoke(
-                run, ["--host", "0.0.0.0", "--port", "24272", "--reload"]
+                serve, ["--host", "0.0.0.0", "--port", "24272", "--reload"]
             )
             assert result.exit_code == 0
             assert not result.exception
@@ -288,10 +288,10 @@ class TestRun:
                 "bibra.main:app", host="0.0.0.0", port=24272, reload=True
             )
 
-    def test_run_with_short_port_option(self):
-        """Test that run passes the short -p port option to uvicorn.run."""
+    def test_serve_with_short_port_option(self):
+        """Test that serve passes the short -p port option to uvicorn.run."""
         with patch("bibra.cli.uvicorn.run") as mock_uvicorn_run:
-            result = self.runner.invoke(run, ["-p", "9999"])
+            result = self.runner.invoke(serve, ["-p", "9999"])
             assert result.exit_code == 0
             assert not result.exception
             mock_uvicorn_run.assert_called_once_with(


### PR DESCRIPTION
## Reasons for creating this PR
A dedicated command to serve the API and web UI is handy.

## Link to relevant issue(s), if any

- Closes #103 

## Description of the changes in this PR
- Adds the command to cli.py, usage is `uv run bibra serve` or just `bibra serve` when in venv.
- Add unit tests for the new command.
- Updates README instruction to start BIBRA API server by running the new command instead of `uv run uvicorn bibra.main:app`.

## Instructions how to test this PR
Run  `uv run bibra run` with various flags.

## Known problems or uncertainties in this PR
What should the name of the command be?

Now the usage is `bibra run`, but would `bibra serve` be better? Especially `uv run bibra run` is a bit awkward.

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.

- 🟡 AI:AMBER	AI-generated, fully reviewed line by line. Author can explain every part.

Describe the AI tool(s) you used: 

<!-- Examples: -->
Zoo Code with Qwen3.8-27B
<!-- Dirac with Qwen3.6-27B -->
<!-- GitHub Copilot code review -->
