### PR TITLE
Fix slow CLI start-up

### DIFF
--- a/bibra/backend/__init__.py
+++ b/bibra/backend/__init__.py
@@ -1,15 +1,21 @@
-from bibra.backend.base import BaseBackend
-from bibra.backend.config import GlobalLLMConfig
-from bibra.backend.dummy import DummyBackend
-from bibra.backend.greylitlm import GreyLitLMBackend, GreyLitLMConfig
-from bibra.backend.nuextract import NuExtractBackend, NuExtractConfig
+import importlib
+from typing import Any
 
-__all__ = [
-    "BaseBackend",
-    "DummyBackend",
-    "GlobalLLMConfig",
-    "GreyLitLMBackend",
-    "GreyLitLMConfig",
-    "NuExtractBackend",
-    "NuExtractConfig",
-]
+_LAZY_MODULES: dict[str, list[str]] = {
+    "bibra.backend.base": ["BaseBackend"],
+    "bibra.backend.config": ["GlobalLLMConfig"],
+    "bibra.backend.dummy": ["DummyBackend"],
+    "bibra.backend.greylitlm": ["GreyLitLMBackend", "GreyLitLMConfig"],
+    "bibra.backend.nuextract": ["NuExtractBackend", "NuExtractConfig"],
+}
+
+# Derived from _LAZY_MODULES to avoid duplication of the names
+__all__ = [name for names in _LAZY_MODULES.values() for name in names]
+
+
+def __getattr__(name: str) -> Any:
+    """Import and return a lazily re-exported backend name on access."""
+    for module, names in _LAZY_MODULES.items():
+        if name in names:
+            return getattr(importlib.import_module(module), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/bibra/backend/__init__.py
+++ b/bibra/backend/__init__.py
@@ -1,26 +1,3 @@
-import importlib
-from typing import Any
+from bibra.backend.base import BaseBackend
 
-_LAZY_MODULES: dict[str, list[str]] = {
-    "bibra.backend.base": ["BaseBackend"],
-    "bibra.backend.config": ["GlobalLLMConfig"],
-    "bibra.backend.dummy": ["DummyBackend"],
-    "bibra.backend.greylitlm": ["GreyLitLMBackend", "GreyLitLMConfig"],
-    "bibra.backend.nuextract": ["NuExtractBackend", "NuExtractConfig"],
-}
-
-# Derived from _LAZY_MODULES to avoid duplication of the names
-__all__ = [name for names in _LAZY_MODULES.values() for name in names]
-
-
-def __getattr__(name: str) -> Any:
-    """Import and return a lazily re-exported backend name on access."""
-    for module, names in _LAZY_MODULES.items():
-        if name in names:
-            return getattr(importlib.import_module(module), name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    """Return module attributes, including lazily exported names."""
-    return sorted(set(globals()) | set(__all__))
+__all__ = ["BaseBackend"]

--- a/bibra/backend/__init__.py
+++ b/bibra/backend/__init__.py
@@ -19,3 +19,8 @@ def __getattr__(name: str) -> Any:
         if name in names:
             return getattr(importlib.import_module(module), name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return module attributes, including lazily exported names."""
+    return sorted(set(globals()) | set(__all__))

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -4,6 +4,7 @@ This module provides project configuration loading from TOML files,
 with support for environment variable interpolation.
 """
 
+import importlib
 import os
 import tomllib
 from dataclasses import dataclass, field
@@ -13,9 +14,6 @@ from typing import Any
 from pydantic import ValidationError
 
 from bibra.backend.base import BaseBackend
-from bibra.backend.dummy import DummyBackend
-from bibra.backend.greylitlm import GreyLitLMBackend
-from bibra.backend.nuextract import NuExtractBackend
 
 
 class ConfigError(Exception):
@@ -51,11 +49,26 @@ class BackendConfigError(ConfigError):
     description = "Invalid backend configuration"
 
 
-_BACKEND_MAP: dict[str, type[BaseBackend]] = {
-    "dummy": DummyBackend,
-    "greylitlm": GreyLitLMBackend,
-    "nuextract": NuExtractBackend,
+# Map of backend type -> "module.ClassName" import path.
+_BACKEND_MAP: dict[str, str] = {
+    "dummy": "bibra.backend.dummy:DummyBackend",
+    "greylitlm": "bibra.backend.greylitlm:GreyLitLMBackend",
+    "nuextract": "bibra.backend.nuextract:NuExtractBackend",
 }
+
+
+def _get_backend_class(backend_type: str) -> type[BaseBackend] | None:
+    """Import and return the backend class for the given backend type.
+
+    Backend modules are imported on demand (and cached by Python's
+    import machinery) to keep CLI startup fast.
+    """
+    if backend_type not in _BACKEND_MAP:
+        return None
+    import_path = _BACKEND_MAP.get(backend_type)
+    module_path, class_name = import_path.split(":", 1)
+    return getattr(importlib.import_module(module_path), class_name)
+
 
 # Keys recognized as global/project-level metadata.
 # All other keys are passed as-is into the backend-specific ``extra`` dict.
@@ -245,7 +258,7 @@ class ProjectRegistry:
         if project is None:
             raise ProjectNotFoundError(f"Unknown project: {project_id}")
 
-        backend_class = _BACKEND_MAP.get(project.backend)
+        backend_class = _get_backend_class(project.backend)
         if backend_class is None:
             raise BackendConfigError(
                 f"Unknown backend type for project '{project_id}': {project.backend}"

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from bibra.backend.base import BaseBackend
+from bibra.backend import BaseBackend
 
 
 class ConfigError(Exception):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,9 @@
 
 import importlib
 import json
+import subprocess
+import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -266,3 +269,39 @@ class TestMakeListTemplate:
         # Should use max of heading and row lengths
         expected = "{:<2}  {:<16}"
         assert template == expected
+
+
+class TestCliStartupTime:
+    """Startup time regression tests for the CLI to avoid accidentally making
+    it slow to start.
+    """
+
+    MAX_HELP_WALL_TIME_S = 0.5
+    RUNS = 3
+    HELP_CMD: tuple[str, ...] = (
+        sys.executable,
+        "-c",
+        "from bibra.cli import cli; cli()",
+        "--help",
+    )
+
+    @classmethod
+    def _run_help(cls) -> float:
+        """Run `bibra --help` in a fresh subprocess and return the wall time."""
+        start = time.perf_counter()
+        subprocess.run(cls.HELP_CMD, check=True, capture_output=True)
+        return time.perf_counter() - start
+
+    def test_cli_help_starts_fast(self):
+        """`bibra --help` must stay fast in a fresh interpreter.
+
+        The minimum of several runs is used so that a single cold-cache or
+        transiently slow measurement cannot fail the test, while a genuine
+        regression (all runs slow) always does.
+        """
+        times = [self._run_help() for _ in range(self.RUNS)]
+        elapsed = min(times)
+        assert elapsed < self.MAX_HELP_WALL_TIME_S, (
+            f"`bibra --help` took {elapsed:.2f} s (min of {times}); "
+            f"exceeds the {self.MAX_HELP_WALL_TIME_S} s budget."
+        )


### PR DESCRIPTION
## Reasons for creating this PR
Execution of the CLI "helper" commands was slow: `bibra list-projects`, `bibra --help` and `bibra --version` all took three seconds. Such slow CLI response is not good.

## Link to relevant issue(s), if any

- Closes #108 

## Description of the changes in this PR
Improves CLI startup by deferring expensive backend imports until needed.

   - Adds lazy backend imports and re-exports.
   - Adds a CLI startup-time regression test.

Runtime of `bibra --help` decreases from 3.14 seconds to 0.30 seconds.

I hoped pytest runs would get faster too, but
- before two runs took 22 s and 24 s, 
- after two runs took 23 s and 24 s.

so essentially no effect.

## Instructions how to test this PR
Time performance before and after this using

    for i in $(seq 1 10); do /usr/bin/time -f "%e s" bibra --help >/dev/null; done

## Known problems or uncertainties in this PR
Copilot review [comments](https://github.com/NatLibFi/BIBRA/pull/109#discussion_r3852533255) on missing `__dir__` method, but I'm not sure if that is a real problem.

## Checklist

- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.
- 🟡 AI:AMBER	AI-generated, fully reviewed line by line. Author can explain every part.

Describe the AI tool(s) you used: 

<!-- Examples: -->
Zoo Code with Qwen3.8-27B
<!-- Dirac with Qwen3.6-27B -->
<!-- GitHub Copilot code review -->
