### PR TITLE
Remove obsolete setuptools setting from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ line-length = 88
 # Add the `line-too-long` rule to the enforced rule set.
 extend-select = ["E501"]
 
-[tool.setuptools.packages.find]
-include = ["bibra*"]
-
 [tool.bumpversion]
 current_version = "0.2.0-dev"
 parse = """(?x)


### PR DESCRIPTION
## Reasons for creating this PR
Qwen 3.8 gave a side-note while performing some other task: the setuptools setting

https://github.com/NatLibFi/BIBRA/blob/2a14380b58678ab5c7a644b4673f8e97fc53d03e/pyproject.toml#L52-L53

is unnecessary when using uv as a build backend.

## Link to relevant issue(s), if any


## Description of the changes in this PR
The unnecessary and confusing setting is removed.

## Instructions how to test this PR

    uv build

then install the build output in a new venv

    pip install <path>/dist/bibra-0.2.0.dev0.tar.g

and check that CLI works.

## Known problems or uncertainties in this PR


## Checklist


- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.
- 🟢 AI:GREEN	AI-assisted. Author drove the process, AI used as a tool (autocomplete, partial generation, refactoring 

Describe the AI tool(s) you used: 

<!-- Examples: -->
Zoo Code with Qwen3.8-27B
<!-- Dirac with Qwen3.6-27B -->
<!-- GitHub Copilot code review -->
