### PR TITLE
Refine API documentation

### DIFF
--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -13,7 +13,7 @@ from bibra.types import PublicationMetadata
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(tags=["v0"])
 
 
 def get_registry(request: Request) -> ProjectRegistry:
@@ -30,13 +30,13 @@ def get_registry(request: Request) -> ProjectRegistry:
     return registry
 
 
-@router.get("/")
+@router.get("/", response_model=dict, summary="Get version information")
 async def root():
-    """Return the API version information."""
+    """Return version information of BIBRA and the API."""
     return {"version": __version__, "message": "Welcome to BIBRA API v0"}
 
 
-@router.get("/projects")
+@router.get("/projects", response_model=dict, summary="List projects")
 async def list_projects(registry: Annotated[ProjectRegistry, Depends(get_registry)]):
     """Return a list of configured projects."""
     try:
@@ -49,6 +49,7 @@ async def list_projects(registry: Annotated[ProjectRegistry, Depends(get_registr
 
 @router.post(
     "/projects/{project_id}/extract",
+    summary="Extract metadata",
     responses={400: {"description": "Bad Request - malformed multipart data"}},
 )
 async def extract(
@@ -65,6 +66,12 @@ async def extract(
 
     Returns:
         PublicationMetadata: Extracted metadata as JSON
+
+    Example:
+        ```
+        curl -X POST "http://localhost:8000/v0/projects/my_project/extract" \
+             -F "files=@/path/to/document.pdf"
+        ```
     """
     temp_files: list[str] = []
     try:

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 
 from bibra import __version__
 from bibra.config import ConfigError, ProjectNotFoundError, ProjectRegistry
-from bibra.types import PublicationMetadata
+from bibra.types import Projects, PublicationMetadata, Version
 
 logger = logging.getLogger(__name__)
 
@@ -30,13 +30,13 @@ def get_registry(request: Request) -> ProjectRegistry:
     return registry
 
 
-@router.get("/", response_model=dict, summary="Get version information")
+@router.get("/", response_model=Version, summary="Get version information")
 async def root():
     """Return version information of BIBRA and the API."""
     return {"version": __version__, "message": "Welcome to BIBRA API v0"}
 
 
-@router.get("/projects", response_model=dict, summary="List projects")
+@router.get("/projects", response_model=Projects, summary="List projects")
 async def list_projects(registry: Annotated[ProjectRegistry, Depends(get_registry)]):
     """Return a list of configured projects."""
     try:

--- a/bibra/api/v0/routes.py
+++ b/bibra/api/v0/routes.py
@@ -13,7 +13,7 @@ from bibra.types import Projects, PublicationMetadata, Version
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["v0"])
+router = APIRouter()
 
 
 def get_registry(request: Request) -> ProjectRegistry:
@@ -30,13 +30,17 @@ def get_registry(request: Request) -> ProjectRegistry:
     return registry
 
 
-@router.get("/", response_model=Version, summary="Get version information")
+@router.get(
+    "/", response_model=Version, summary="Get version information", tags=["General"]
+)
 async def root():
     """Return version information of BIBRA and the API."""
     return {"version": __version__, "message": "Welcome to BIBRA API v0"}
 
 
-@router.get("/projects", response_model=Projects, summary="List projects")
+@router.get(
+    "/projects", response_model=Projects, summary="List projects", tags=["Projects"]
+)
 async def list_projects(registry: Annotated[ProjectRegistry, Depends(get_registry)]):
     """Return a list of configured projects."""
     try:
@@ -50,6 +54,7 @@ async def list_projects(registry: Annotated[ProjectRegistry, Depends(get_registr
 @router.post(
     "/projects/{project_id}/extract",
     summary="Extract metadata",
+    tags=["Extraction"],
     responses={400: {"description": "Bad Request - malformed multipart data"}},
 )
 async def extract(

--- a/bibra/main.py
+++ b/bibra/main.py
@@ -36,7 +36,7 @@ elif os.path.isdir("node_modules"):  # ...or in the current directory
     )
 
 
-@app.get("/", response_class=HTMLResponse)
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def root():
     """Return the static index.html page."""
     return FileResponse(files("bibra").joinpath("static/index.html"))

--- a/bibra/types/__init__.py
+++ b/bibra/types/__init__.py
@@ -1,6 +1,37 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class Version(BaseModel):
+    """Response model for the root endpoint."""
+
+    version: str = Field(
+        ..., description="Current BIBRA version string", examples=["0.1.0"]
+    )
+    message: str = Field(
+        ..., description="Welcome message", examples=["Welcome to BIBRA API v0"]
+    )
+
+
+class ProjectInfo(BaseModel):
+    """Summary information for a single configured project."""
+
+    id: str = Field(..., description="Project identifier", examples=["my_project"])
+    name: str = Field(
+        ..., description="Human-readable project name", examples=["My Project"]
+    )
+    description: str = Field(
+        ...,
+        description="Short description of the project",
+        examples=["Project using dummy backend"],
+    )
+
+
+class Projects(BaseModel):
+    """Response model for the list-projects endpoint."""
+
+    projects: list[ProjectInfo] = Field(..., description="List of configured projects")
+
+
 class PublicationMetadata(BaseModel):
     """Response model for publication metadata extraction."""
 


### PR DESCRIPTION
## Reasons for creating this PR
The interactive Swagger API documentation (/docs endpoint) has some flaws and potential for improvement:
1. It shows "default" as a subtitle for all the methods
2. The root / is included in the methods list, while it returns the static index.html page and should not be included in the API endpoint list(?) (/v0/ returns API version information)
3. The example value of /v0/projects is "string" while in reality the response is a JSON object
4. A curl example for how to upload a file to /extract method would ease typical use

## Link to relevant issue(s), if any

- Closes #

## Description of the changes in this PR
1. Add tags for categories of the methods
2. Hide root / using `include_in_schema=False`
3. Responses schemas are added and shown as examples.
5. A curl example is added to for the extract method: 
    ```
    curl -X POST "http://localhost:8000/v0/projects/my_project/extract" -F "files=@/path/to/document.pdf"
    ```

## Instructions how to test this PR
Run by yourself

    uv run uvicorn bibra.main:app --reload

or take a look below.

### Before 
Screenshot of the current [API docs](https://bibra.apps.ocp-kk-test-1.k8s.it.helsinki.fi/docs#/default/extract_v0_projects__project_id__extract_post).
<img width="1191" height="1322" alt="image" src="https://github.com/user-attachments/assets/cb4412b8-43e4-4fda-a239-a6058b34ce7c" />

### After
With the changes of this PR:


<img width="1191" height="1322" alt="image" src="https://github.com/user-attachments/assets/6d6eca73-c470-4846-a244-f4f8a72f0d2b" />

## Known problems or uncertainties in this PR
Should the static index.html page be included in the API endpoint list?

## Checklist
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.

- 🟢 AI:GREEN	AI-assisted. Author drove the process, AI used as a tool (autocomplete, partial generation, refactoring help).


##  Describe the AI tool(s) you used:
<!-- Examples: -->
 - Zoo Code with Qwen3.6-35B-A3B
 - Zoo Code with Claude Sonnet 4.6 
<!-- Dirac with Qwen3.6-27B -->
<!-- GitHub Copilot code review -->
