### PR TITLE
Use new extract-url REST API endpoint in frontend

### DIFF
--- a/bibra/static/css/styles.css
+++ b/bibra/static/css/styles.css
@@ -2,7 +2,7 @@
   /* Color definitions */
   --dark-color: #0d284e;
   --muted-color: #6C778A;
-  --medium-color: #1b709d ;
+  --medium-color: #1b709d;
   --secondary-medium-color: #b8c9db;
   --light-color: #dfe5ed;
   --secondary-light-color: #f2f5f7;
@@ -58,7 +58,8 @@ a {
 
 .btn-clear {
   background-color: var(--dark-color);
-  color: white;padding-right: 2.5rem;
+  color: var(--white-color);
+  padding-right: 2.5rem;
   position: relative;
 }
 
@@ -106,13 +107,45 @@ a {
   font-size: 0.9rem;
 }
 
+#url-preview {
+  border-left: 5px solid var(--accent-color);
+  background-color: var(--white-color);
+}
+
+#url-preview a {
+  position: relative;
+}
+
+#url-preview i {
+  color: var(--dark-color);
+  font-size: 11px;
+  margin-left: 0.125rem;
+  position: absolute;
+  bottom: 5px;
+}
+
+#url-preview p:last-child {
+  font-size: 0.9rem;
+  color: var(--muted-color);
+}
+
 #file-preview iframe {
   width: 100%;
   height: 450px;
 }
 
 #file-preview .btn-clear {
-  padding-right: 3rem;
+  background-color: var(--secondary-medium-color);
+  color: var(--dark-color);
+}
+
+#file-preview .btn-clear span {
+  display: inline-block;
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 .input-label {
@@ -141,14 +174,14 @@ a {
 }
 
 #select-method {
-  width: 100%;
+  flex: 2;
   border: 1px solid var(--secondary-medium-color);
 }
 
 .btn-submit {
+  flex: 1;
   background-color: var(--accent-color) !important;
   color: var(--dark-color) !important;
-  width: 50%;
 }
 
 .btn-submit.disabled {
@@ -159,6 +192,10 @@ a {
 
 #results p {
   font-size: 0.9rem;
+}
+
+#results i.fa-spinner {
+  margin-top: 0.75rem;
 }
 
 #results .table {
@@ -175,10 +212,6 @@ a {
   vertical-align: middle;
   padding-left: 0;
   padding-right: 1rem;
-}
-
-#results .table-col-field {
-  width: 20%;
 }
 
 #results .table-col-value {
@@ -203,5 +236,5 @@ a {
 }
 
 #version-info {
-  color:var(--muted-color);
+  color: var(--muted-color);
 }

--- a/bibra/static/js/bibra.js
+++ b/bibra/static/js/bibra.js
@@ -2,12 +2,12 @@ const mainApp = Vue.createApp({
   data () {
     return {
       extractPending: false,
+      errorMessageExtract: '',
       loadingResults: false,
       projects: [],
       results: {},
       selectedProject: '',
       showDraggingEffect: false,
-      showErrorMessageExtract: false,
       showErrorMessageFileType: false,
       showResults: false,
       source: null, // null | { type: 'file', blob, objectUrl, name } | { type: 'url', url }
@@ -51,11 +51,11 @@ const mainApp = Vue.createApp({
       // Reset input data
       if (this.isFileSource) URL.revokeObjectURL(this.source.objectUrl)
       this.extractPending = false
+      this.errorMessageExtract = ''
       this.loadingResults = false
       this.results = {}
       this.showResults = false
       this.showErrorMessageFileType = false
-      this.showErrorMessageExtract = false
       this.source = null
       this.url = ''
     },
@@ -121,14 +121,14 @@ const mainApp = Vue.createApp({
 
       this.source = { type: 'url', url: this.url }
     },
-    extract () {
+    async extract () {
       if (this.extractPending) return // Only call extract if a previous call is not pending
 
       this.extractPending = true
+      this.errorMessageExtract = ''
+      this.loadingResults = true
       this.results = {}
       this.showResults = false
-      this.loadingResults = true
-      this.showErrorMessageExtract = false
 
       const formData = new FormData()
       if (this.isUrlSource) {
@@ -138,34 +138,37 @@ const mainApp = Vue.createApp({
       }
       const endpoint = this.isUrlSource ? 'extract-url' : 'extract'
 
-      fetch(`/v0/projects/${this.selectedProject}/${endpoint}`, {
-        method: 'POST',
-        body: formData
-      })
-        .then(res => {
-          if (!res.ok) {
-            throw new Error(`Server responded with ${res.status}`)
-          }
-          return res.json()
-        })
-        .then(data => {
-          // Only show results if request wasn't cancelled by user
-          if (this.extractPending) {
-            this.results = data
-            this.showResults = true
-          }
-        })
-        .catch(err => {
-          console.error('Failed to extract data:', err)
+      try {
+        const res = await fetch(`/v0/projects/${this.selectedProject}/${endpoint}`, { method: 'POST', body: formData })
+        const data = await res.json()
+
+        if (!res.ok) {
+          console.error('Failed to extract data:', data.detail)
           // Only show error if request wasn't cancelled by user
           if (this.extractPending) {
-            this.showErrorMessageExtract = true
+            this.results = {}
+            this.showResults = false
+            this.errorMessageExtract = data.detail
           }
-        })
-        .finally(() => {
-          this.loadingResults = false
-          this.extractPending = false
-        })
+          return
+        }
+
+        if (this.extractPending) {
+          this.results = data
+          this.showResults = true
+        }
+      } catch (err) {
+        console.error('Failed to extract data:', err)
+        // Only show error if request wasn't cancelled by user
+        if (this.extractPending) {
+          this.results = {}
+          this.showResults = false
+          this.errorMessageExtract = 'Metadata extraction failed.'
+        }
+      } finally {
+        this.loadingResults = false
+        this.extractPending = false
+      }
     }
   },
   template: `
@@ -217,7 +220,9 @@ const mainApp = Vue.createApp({
             <div class="mb-3">
               <div v-if="isUrlSource" id="url-preview" class="p-3">
                 <p class="mb-2">
-                  Using document: <a :href="url" target="_blank">{{ url }}<i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                  Using document: <a :href="url" title="Open document in a new tab" target="_blank">
+                    {{ url }}<i class="fa-solid fa-arrow-up-right-from-square"></i>
+                  </a>
                 </p>
                 <p class="mb-0">
                   The file is downloaded and validated on the server after submission.
@@ -262,8 +267,8 @@ const mainApp = Vue.createApp({
           <h2 class="mb-3">Results</h2>
           <template v-if="!showResults">
             <template v-if="!loadingResults">
-              <div v-if="showErrorMessageExtract" class="error-message p-2" role="alert">
-                Metadata extraction failed.
+              <div v-if="errorMessageExtract" class="error-message p-2" role="alert">
+                {{ errorMessageExtract }}
               </div>
               <p v-else>Results will appear here after processing</p>
             </template>
@@ -298,7 +303,7 @@ const mainApp = Vue.createApp({
                     <td class="table-col-copy">
                       <button class="btn-copy btn btn-secondary" @click="copy(value)">
                         <i class="fa-regular fa-copy" aria-hidden="true"></i>
-                        <span class="visually-hidden">Copy</span>
+                        <span class="visually-hidden">Copy {{ key }}</span>
                       </button>
                     </td>
                   </tr>

--- a/bibra/static/js/bibra.js
+++ b/bibra/static/js/bibra.js
@@ -2,9 +2,6 @@ const mainApp = Vue.createApp({
   data () {
     return {
       extractPending: false,
-      fileBlob: null,
-      fileName: '',
-      fileObjectUrl: null,
       loadingResults: false,
       projects: [],
       results: {},
@@ -12,12 +9,15 @@ const mainApp = Vue.createApp({
       showDraggingEffect: false,
       showErrorMessageExtract: false,
       showErrorMessageFileType: false,
-      showErrorMessageURL: false,
-      showPreview: false,
       showResults: false,
+      source: null, // null | { type: 'file', blob, objectUrl, name } | { type: 'url', url }
       url: '',
       version: ''
     }
+  },
+  computed: {
+    isUrlSource () { return this.source?.type === 'url' },
+    isFileSource () { return this.source?.type === 'file' }
   },
   mounted () {
     // Fetch BIBRA version information
@@ -49,18 +49,15 @@ const mainApp = Vue.createApp({
   methods: {
     clearInput () {
       // Reset input data
-      this.url = ''
-      this.fileBlob = null
-      URL.revokeObjectURL(this.fileObjectUrl) // Revoke assigned blob URL from uploaded file
-      this.fileObjectUrl = null
-      this.fileName = ''
-      this.results = {}
-      this.showPreview = false
-      this.showResults = false
+      if (this.isFileSource) URL.revokeObjectURL(this.source.objectUrl)
+      this.extractPending = false
       this.loadingResults = false
+      this.results = {}
+      this.showResults = false
       this.showErrorMessageFileType = false
       this.showErrorMessageExtract = false
-      this.showErrorMessageURL = false
+      this.source = null
+      this.url = ''
     },
     copy (value) {
       if (Array.isArray(value)) {
@@ -89,98 +86,86 @@ const mainApp = Vue.createApp({
       e.stopPropagation()
       e.preventDefault()
       this.showDraggingEffect = false
-      this.showErrorMessageFileType = false
-      this.showErrorMessageURL = false
       
-      const file = e.dataTransfer.files[0]
-      if (file && file.type === 'application/pdf') {
-        this.fileBlob = file
-        this.fileObjectUrl = URL.createObjectURL(this.fileBlob)
-        this.fileName = this.fileBlob.name
-        this.showPreview = true
-      } else {
-        this.showErrorMessageFileType = true
-      }
+      this.setFile(e.dataTransfer.files[0])
     },
     handleDropzoneClick (e) {
-      this.showErrorMessageFileType = false
-      this.showErrorMessageURL = false
-
       e.preventDefault()
       // Click hidden file input to run uploadFile method
       this.$refs.file.click()
     },
-    loadFileFromUrl (e) {
-      e.preventDefault()
-      this.showErrorMessageFileType = false
-      this.showErrorMessageURL = false
-
-      // Load file from given URL
-      fetch(this.url)
-        .then(res => res.blob())
-        .then(res => {
-          if (res.type === 'application/pdf') {
-            // Store the fetched file as a blob and assign a blob URL to it
-            this.fileBlob = res
-            this.fileObjectUrl = URL.createObjectURL(this.fileBlob)
-            this.fileName = this.url.split('/').slice(-1)[0]
-            this.showPreview = true
-          } else {
-            this.showErrorMessageFileType = true
-          }
-        })
-      .catch(err => {
-        console.error('Failed to fetch file from URL:', err)
-        this.showErrorMessageURL = true
-      })
-    },
     uploadFile (e) {
+      this.setFile(e.target.files[0])
+    },
+    setFile (file) {
       this.showErrorMessageFileType = false
-      this.showErrorMessageURL = false
 
-      const file = e.target.files[0]
-      if (file && file.type === 'application/pdf') {
-        // Store the uploaded file as a blob and assign a blob URL to it
-        this.fileBlob = file
-        this.fileObjectUrl = URL.createObjectURL(this.fileBlob)
-        this.fileName = this.fileBlob.name
-        this.showPreview = true
-      } else {
+      if (!file || file.type !== 'application/pdf') {
         this.showErrorMessageFileType = true
+        return
+      }
+      if (this.isFileSource) {
+        URL.revokeObjectURL(this.source.objectUrl)
+      }
+      // Store the uploaded file as a blob and assign a blob URL to it
+      this.source = {
+        type: 'file',
+        blob: file,
+        objectUrl: URL.createObjectURL(file),
+        name: file.name
       }
     },
+    setUrl (e) {
+      e.preventDefault()
+      this.showErrorMessageFileType = false
+
+      this.source = { type: 'url', url: this.url }
+    },
     extract () {
+      if (this.extractPending) return // Only call extract if a previous call is not pending
+
+      this.extractPending = true
       this.results = {}
       this.showResults = false
       this.loadingResults = true
       this.showErrorMessageExtract = false
 
-      // Only call extract if a previous call is not pending
-      if (!this.extractPending) {
-        this.extractPending = true
+      const formData = new FormData()
+      if (this.isUrlSource) {
+        formData.append('url', this.source.url)
+      } else {
+        formData.append('files', this.source.blob)
+      }
+      const endpoint = this.isUrlSource ? 'extract-url' : 'extract'
 
-        const formData = new FormData()
-        formData.append('files', this.fileBlob)
-
-        fetch(`/v0/projects/${this.selectedProject}/extract`, {
-          method: 'POST',
-          body: formData
+      fetch(`/v0/projects/${this.selectedProject}/${endpoint}`, {
+        method: 'POST',
+        body: formData
+      })
+        .then(res => {
+          if (!res.ok) {
+            throw new Error(`Server responded with ${res.status}`)
+          }
+          return res.json()
         })
-          .then(res => res.json())
-          .then(data => {
+        .then(data => {
+          // Only show results if request wasn't cancelled by user
+          if (this.extractPending) {
             this.results = data
-            this.loadingResults = false
             this.showResults = true
-            this.extractPending = false
-          })
+          }
+        })
         .catch(err => {
-          console.error('Failed to extract data from file:', err)
-
+          console.error('Failed to extract data:', err)
+          // Only show error if request wasn't cancelled by user
+          if (this.extractPending) {
+            this.showErrorMessageExtract = true
+          }
+        })
+        .finally(() => {
           this.loadingResults = false
           this.extractPending = false
-          this.showErrorMessageExtract = true
         })
-      }
     }
   },
   template: `
@@ -190,7 +175,7 @@ const mainApp = Vue.createApp({
           <div class="d-flex mb-3">
             <h2 class="my-auto">Input</h2>
             <button class="btn-clear ms-auto btn btn-primary"
-              v-if="showPreview"
+              v-if="source"
               @click="clearInput()"
             >
               Clear input
@@ -198,7 +183,7 @@ const mainApp = Vue.createApp({
             </button>
           </div>
 
-          <template v-if="!showPreview">
+          <template v-if="!source">
             <div id="dropzone" class="mb-3" role="button" tabindex="0"
               :class="{ 'dragging': showDraggingEffect }"
               @click="handleDropzoneClick($event)"
@@ -218,31 +203,40 @@ const mainApp = Vue.createApp({
 
             <div id="fetch-from-url" class="mb-3">
               <label class="input-label" for="url-input">Or fetch from URL</label>
-              <form class="input-group" @submit="loadFileFromUrl($event)">
+              <form class="input-group" @submit="setUrl($event)">
                 <input id="url-input" class="form-control" type="url" placeholder="https://example.com/document.pdf" required v-model="url">
-                <input id="button-select-url" class="btn btn-primary" type="submit"  value="Fetch PDF">
+                <input id="button-select-url" class="btn btn-primary" type="submit"  value="Select URL">
               </form>
             </div>
 
-            <div class="error-message mb-3 p-2" role="alert" v-if="showErrorMessageFileType || showErrorMessageURL">
-              <span v-if="showErrorMessageFileType">This file format is not supported. Please select a PDF document.</span>
-              <span v-else>Failed to fetch file from URL.</span>
+            <div class="error-message mb-3 p-2" role="alert" v-if="showErrorMessageFileType">
+              <span>This file format is not supported. Please select a PDF document.</span>
             </div>
           </template>
           <template v-else>
-            <div id="file-preview" class="mb-3">
-              <iframe class="mb-3"
-                :src="fileObjectUrl"
-                :data-url="fileObjectUrl"
-              ></iframe>
-              <button class="btn-clear btn btn-secondary"
-                :aria-label="'Remove ' + fileName"
-                @click="clearInput()"
-              >
-                <i class="fa-solid fa-file" aria-hidden="true"></i>
-                <span>{{ fileName }}</span>
-                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
-              </button>
+            <div class="mb-3">
+              <div v-if="isUrlSource" id="url-preview" class="p-3">
+                <p class="mb-2">
+                  Using document: <a :href="url" target="_blank">{{ url }}<i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                </p>
+                <p class="mb-0">
+                  The file is downloaded and validated on the server after submission.
+                </p>
+              </div>
+              <div v-else id="file-preview">
+                <iframe class="mb-3"
+                  :title="source.name"
+                  :src="source.objectUrl"
+                ></iframe>
+                <button class="btn-clear btn btn-secondary"
+                  :aria-label="'Remove ' + source.name"
+                  @click="clearInput()"
+                >
+                  <i class="fa-solid fa-file me-1" aria-hidden="true"></i>
+                  <span>{{ source.name }}</span>
+                  <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+              </div>
             </div>
           </template>
 
@@ -258,8 +252,8 @@ const mainApp = Vue.createApp({
             
             <button class="btn-submit btn btn-primary fw-bold"
               @click="extract()"
-              :class="{ disabled: !showPreview || loadingResults }"
-              :disabled="!showPreview || loadingResults"
+              :class="{ disabled: !source || loadingResults }"
+              :disabled="!source || loadingResults"
             >Submit</button>
           </div>
         </div>

--- a/cypress/e2e/home-page.cy.js
+++ b/cypress/e2e/home-page.cy.js
@@ -38,6 +38,7 @@ describe('Home Page', () => {
     cy.get('#fetch-from-url').should('not.exist')
     // Check that preview is visible
     cy.get('#file-preview').should('be.visible')
+    cy.get('#url-preview').should('not.exist')
     cy.get('.btn-clear').should('have.length', 2)
   })
 
@@ -48,17 +49,20 @@ describe('Home Page', () => {
     cy.get('#dropzone').selectFile('cypress/fixtures/test-document.pdf', { action: 'drag-drop' })
     // Check that preview is visible
     cy.get('#file-preview').should('be.visible')
+    cy.get('#url-preview').should('not.exist')
   })
 
   it('fetches files from URL', () => {
-    // Check that file preview is not visible
-    cy.get('#file-preview').should('not.exist')
+    // Check that URL preview is not visible
+    cy.get('#url-preview').should('not.exist')
     // Type in pdf url
     cy.get('#url-input').type('https://pdfobject.com/pdf/sample.pdf')
     // Click button to fetch pdf
     cy.get('#button-select-url').click()
     // Check that preview is visible
-    cy.get('#file-preview').should('be.visible')
+    cy.get('#url-preview').should('be.visible')
+    // Check that URL is displayed
+    cy.get('#url-preview a').invoke('text').should('contain', 'https://pdfobject.com/pdf/sample.pdf')
   })
 
   it('shows results after submit', () => {
@@ -80,7 +84,7 @@ describe('Home Page', () => {
     cy.get('#results table').should('be.visible')
     // Check that copy buttons copy correct values
     cy.get('.btn-copy').eq(0).click()
-    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'en');
+    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'en')
   })
 
   it('hides preview and results after clear', () => {
@@ -101,6 +105,7 @@ describe('Home Page', () => {
     cy.get('#dropzone').should('be.visible')
     cy.get('#fetch-from-url').should('be.visible')
     cy.get('#file-preview').should('not.exist')
+    cy.get('#url-preview').should('not.exist')
     cy.get('.btn-clear').should('not.exist')
   })
 
@@ -112,12 +117,6 @@ describe('Home Page', () => {
     // Check that correct error message is displayed
     cy.get('.error-message').should('have.length', 1)
     cy.get('.error-message').eq(0).invoke('text').should('contain', 'This file format is not supported. Please select a PDF document.')
-    // Input faulty URL
-    cy.get('#url-input').type('https://example.com/')
-    cy.get('#button-select-url').click()
-    // Check that correct error message is displayed
-    cy.get('.error-message').should('have.length', 1)
-    cy.get('.error-message').eq(0).invoke('text').should('contain', 'Failed to fetch file from URL.')
 
     // Intercept and block all POST requests
     cy.intercept({


### PR DESCRIPTION
## Reasons for creating this PR

This PR makes it possible to extract metadata directly from a URL in the UI, by making use of the new `extract-url` REST API method.

## Link to relevant issue(s), if any

- Closes #36

## Description of the changes in this PR

- Use new `extract-url` endpoint in the UI
- Add a preview for URLs with a link to the URL
- Refactor Vue code to unify input state to a single `source` object
- Small improvements to CSS
- Fix cypress tests

## Instructions how to test this PR

- Use a URL pointing to a valid PDF file and click select URL
- Check that URL preview is shown
- Click submit and check that metadata is extracted

## Known problems or uncertainties in this PR

Error messages sent from the backend are not currently shown in the UI, only a generic "Metadata extraction failed." message.

## Checklist


- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage

- 🟢 AI:GREEN	AI-assisted. Author drove the process, AI used as a tool (autocomplete, partial generation, refactoring help).

Describe the AI tool(s) you used: Zoo Code with Qwen3.6-35B-A3B
