### PR TITLE
Implement adding optional extra_headers in requests to LLM API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Global LLM Settings
 LLM_ENDPOINT_URL=http://localhost:8080/v1/
 LLM_API_KEY=
+#LLM_EXTRA_HEADERS=
 
 # GreyLitLM Settings
 GREYLITLM_MODEL=greylitlm

--- a/bibra/backend/config.py
+++ b/bibra/backend/config.py
@@ -5,6 +5,7 @@ Environment variables are typically loaded from .env files via python-dotenv
 at application startup (see bibra.main and bibra.cli entry points).
 """
 
+import json
 import logging
 import os
 from typing import Any
@@ -38,18 +39,51 @@ def parse_int_or_str(v: Any) -> int:
         return 0
 
 
+def parse_extra_headers(raw: str) -> dict[str, str] | None:
+    """Parse a JSON-encoded string into a mapping of HTTP headers.
+
+    Args:
+        raw: Raw JSON string, e.g. '{"X-Title": "BIBRA"}'.
+
+    Returns:
+        Parsed headers if raw is a valid JSON object with string keys and
+        values, otherwise None (a warning is logged for invalid input).
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("LLM_EXTRA_HEADERS is not valid JSON, ignoring: %r", raw)
+        return None
+    if not (
+        isinstance(parsed, dict)
+        and all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items())
+    ):
+        logger.warning(
+            "LLM_EXTRA_HEADERS must be a JSON object with string values, ignoring: %r",
+            raw,
+        )
+        return None
+    return parsed
+
+
 class GlobalLLMConfig:
     """Shared LLM infrastructure settings.
 
     Environment Variables:
         LLM_ENDPOINT_URL: The URL of the LLM endpoint (default: http://localhost:8080/v1/)
         LLM_API_KEY: API key for authentication (optional, can be None)
+        LLM_EXTRA_HEADERS: JSON object of extra HTTP headers sent with every
+            request, e.g. '{"HTTP-Referer": "https://example.com"}' (optional)
     """
 
     def __init__(
         self,
         endpoint_url: str | None = None,
         api_key: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ):
         """Initialize global LLM configuration.
 
@@ -57,6 +91,9 @@ class GlobalLLMConfig:
             endpoint_url: The URL of the LLM endpoint. Defaults to env var or
                 http://localhost:8080/v1/.
             api_key: API key for authentication. Defaults to env var value.
+            extra_headers: Extra HTTP headers sent with every request. Defaults
+            to the LLM_EXTRA_HEADERS env var (JSON object), or None if
+            unset/unparseable.
         """
         self.endpoint_url = (
             endpoint_url
@@ -64,3 +101,8 @@ class GlobalLLMConfig:
             else os.getenv("LLM_ENDPOINT_URL", "http://localhost:8080/v1/")
         )
         self.api_key = api_key if api_key is not None else os.getenv("LLM_API_KEY")
+        self.extra_headers = (
+            extra_headers
+            if extra_headers is not None
+            else parse_extra_headers(os.getenv("LLM_EXTRA_HEADERS", ""))
+        )

--- a/bibra/backend/config.py
+++ b/bibra/backend/config.py
@@ -55,15 +55,14 @@ def parse_extra_headers(raw: str) -> dict[str, str] | None:
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
-        logger.warning("LLM_EXTRA_HEADERS is not valid JSON, ignoring: %r", raw)
+        logger.warning("LLM_EXTRA_HEADERS is not valid JSON; ignoring value")
         return None
     if not (
         isinstance(parsed, dict)
         and all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items())
     ):
         logger.warning(
-            "LLM_EXTRA_HEADERS must be a JSON object with string values, ignoring: %r",
-            raw,
+            "LLM_EXTRA_HEADERS must be a JSON object with string values; ignoring value"
         )
         return None
     return parsed

--- a/bibra/backend/config.py
+++ b/bibra/backend/config.py
@@ -57,9 +57,8 @@ def parse_extra_headers(raw: str) -> dict[str, str] | None:
     except json.JSONDecodeError:
         logger.warning("LLM_EXTRA_HEADERS is not valid JSON; ignoring value")
         return None
-    if not (
-        isinstance(parsed, dict)
-        and all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items())
+    if not isinstance(parsed, dict) or not all(
+        isinstance(v, str) for v in parsed.values()
     ):
         logger.warning(
             "LLM_EXTRA_HEADERS must be a JSON object with string values; ignoring value"

--- a/bibra/backend/greylitlm.py
+++ b/bibra/backend/greylitlm.py
@@ -64,6 +64,7 @@ class GreyLitLMBackend(BaseBackend):
         openai_client = AsyncOpenAI(
             base_url=self.global_cfg.endpoint_url,
             api_key=api_key,
+            default_headers=self.global_cfg.extra_headers,
         )
 
         # Create the OpenAI provider with the custom client
@@ -90,6 +91,7 @@ class GreyLitLMBackend(BaseBackend):
         global_cfg = GlobalLLMConfig(
             endpoint_url=project.endpoint,
             api_key=project.api_key,
+            extra_headers=project.extra_headers,
         )
         cfg = GreyLitLMConfig(**project.extra)
         return {"global_cfg": global_cfg, "cfg": cfg}

--- a/bibra/backend/nuextract.py
+++ b/bibra/backend/nuextract.py
@@ -140,6 +140,7 @@ class NuExtractBackend(BaseBackend):
         openai_client = AsyncOpenAI(
             base_url=self.global_cfg.endpoint_url,
             api_key=api_key,
+            default_headers=self.global_cfg.extra_headers,
         )
 
         provider = OpenAIProvider(openai_client=openai_client)
@@ -160,6 +161,7 @@ class NuExtractBackend(BaseBackend):
         global_cfg = GlobalLLMConfig(
             endpoint_url=project.endpoint,
             api_key=project.api_key,
+            extra_headers=project.extra_headers,
         )
         cfg = NuExtractConfig(**project.extra)
         return {"global_cfg": global_cfg, "cfg": cfg}

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -161,7 +161,7 @@ def _parse_extra_headers(extra_headers: Any, project_id: str) -> dict[str, str] 
     if extra_headers is None:
         return None
     if not isinstance(extra_headers, dict) or not all(
-        isinstance(k, str) and isinstance(v, str) for k, v in extra_headers.items()
+        isinstance(v, str) for v in extra_headers.values()
     ):
         raise BackendConfigError(
             f"Invalid extra_headers for project '{project_id}':"

--- a/bibra/config.py
+++ b/bibra/config.py
@@ -72,7 +72,7 @@ def _get_backend_class(backend_type: str) -> type[BaseBackend] | None:
 
 # Keys recognized as global/project-level metadata.
 # All other keys are passed as-is into the backend-specific ``extra`` dict.
-_GLOBAL_KEYS = {"name", "backend", "endpoint", "api_key"}
+_GLOBAL_KEYS = {"name", "backend", "endpoint", "api_key", "extra_headers"}
 
 
 @dataclass
@@ -85,6 +85,7 @@ class ProjectConfig:
         backend: Backend type identifier (e.g. "dummy", "greylitlm", "nuextract").
         endpoint: LLM endpoint URL.
         api_key: API key for authentication.
+        extra_headers: Extra HTTP headers sent with every LLM request.
         extra: Backend-specific options passed to the backend's config schema.
     """
 
@@ -93,6 +94,7 @@ class ProjectConfig:
     backend: str
     endpoint: str | None = None
     api_key: str | None = None
+    extra_headers: dict[str, str] | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
 
@@ -140,6 +142,34 @@ def _interpolate_dict_values(d: dict[str, Any]) -> dict[str, Any]:
         key: _interpolate_env_vars(value) if isinstance(value, str) else value
         for key, value in d.items()
     }
+
+
+def _parse_extra_headers(extra_headers: Any, project_id: str) -> dict[str, str] | None:
+    """Validate and interpolate extra_headers from a merged project config.
+
+    Args:
+        extra_headers: Raw extra_headers value from the merged config.
+        project_id: Project ID, used in the error message.
+
+    Returns:
+        Interpolated headers dict, or None if extra_headers is not set.
+
+    Raises:
+        BackendConfigError: If extra_headers is not a table of string
+            key/value pairs.
+    """
+    if extra_headers is None:
+        return None
+    if not isinstance(extra_headers, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in extra_headers.items()
+    ):
+        raise BackendConfigError(
+            f"Invalid extra_headers for project '{project_id}':"
+            " must be a table of string key/value pairs"
+        )
+    # Interpolate env vars in header values (nested dicts are not
+    # covered by _interpolate_dict_values).
+    return {k: _interpolate_env_vars(v) for k, v in extra_headers.items()}
 
 
 class ProjectRegistry:
@@ -220,6 +250,10 @@ class ProjectRegistry:
                 )
 
             # Separate global fields from backend-specific extra fields
+            extra_headers = _parse_extra_headers(
+                merged.get("extra_headers"), project_id
+            )
+
             project = ProjectConfig(
                 id=project_id,
                 name=(
@@ -230,6 +264,7 @@ class ProjectRegistry:
                 backend=backend_type,
                 endpoint=merged.get("endpoint"),
                 api_key=merged.get("api_key"),
+                extra_headers=extra_headers,
                 extra={k: v for k, v in merged.items() if k not in _GLOBAL_KEYS},
             )
 

--- a/projects.toml.example
+++ b/projects.toml.example
@@ -19,14 +19,6 @@ model = "${NUEXTRACT_MODEL}"
 thinking = true
 dpi = 200
 
-# Example: project using OpenRouter, where attribution headers are useful
-# [openrouter]
-# name = "OpenRouter project"
-# backend = "greylitlm"
-# endpoint = "https://openrouter.ai/api/v1/"
-# api_key = "${OPENROUTER_API_KEY}"
-# extra_headers = { HTTP-Referer = "https://example.com", X-Title = "BIBRA" }
-
 [dummy]
 name = "Dummy project"
 backend = "dummy"

--- a/projects.toml.example
+++ b/projects.toml.example
@@ -2,10 +2,7 @@
 # Default settings for all projects (each project can override)
 api_key = "${LLM_API_KEY}"
 endpoint = "${LLM_ENDPOINT_URL}"
-# Extra HTTP headers sent with every LLM request, e.g. for NGINX proxy
-# authentication or OpenRouter attribution. Values support ${ENV_VAR}
-# interpolation.
-#extra_headers = { X-Proxy-Token = "${PROXY_TOKEN}" }
+#extra_headers = { MyHeader = "${MY_ENV}" }
 
 [greylitlm]
 name = "GreyLitLM project"

--- a/projects.toml.example
+++ b/projects.toml.example
@@ -2,6 +2,10 @@
 # Default settings for all projects (each project can override)
 api_key = "${LLM_API_KEY}"
 endpoint = "${LLM_ENDPOINT_URL}"
+# Extra HTTP headers sent with every LLM request, e.g. for NGINX proxy
+# authentication or OpenRouter attribution. Values support ${ENV_VAR}
+# interpolation.
+#extra_headers = { X-Proxy-Token = "${PROXY_TOKEN}" }
 
 [greylitlm]
 name = "GreyLitLM project"
@@ -14,6 +18,14 @@ backend = "nuextract"
 model = "${NUEXTRACT_MODEL}"
 thinking = true
 dpi = 200
+
+# Example: project using OpenRouter, where attribution headers are useful
+# [openrouter]
+# name = "OpenRouter project"
+# backend = "greylitlm"
+# endpoint = "https://openrouter.ai/api/v1/"
+# api_key = "${OPENROUTER_API_KEY}"
+# extra_headers = { HTTP-Referer = "https://example.com", X-Title = "BIBRA" }
 
 [dummy]
 name = "Dummy project"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,6 +244,110 @@ class TestProjectRegistry:
 
         assert projects["proj_a"].api_key == "interpolated-key"
 
+    def test_extra_headers_inline_table_from_toml(self, tmp_path: Path):
+        """Test that extra_headers inline table is parsed from TOML."""
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[test_project]\n"
+            'name = "Test"\n'
+            'backend = "dummy"\n'
+            'extra_headers = { X-Title = "BIBRA" }\n'
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        projects = registry.load()
+
+        assert projects["test_project"].extra_headers == {"X-Title": "BIBRA"}
+        assert "extra_headers" not in projects["test_project"].extra
+
+    def test_extra_headers_subtable_from_toml(self, tmp_path: Path):
+        """Test that extra_headers sub-table (multiple headers) is parsed."""
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[test_project]\n"
+            'name = "Test"\n'
+            'backend = "dummy"\n\n'
+            "[test_project.extra_headers]\n"
+            'X-Title = "BIBRA"\n'
+            'HTTP-Referer = "https://example.com"\n'
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        projects = registry.load()
+
+        assert projects["test_project"].extra_headers == {
+            "X-Title": "BIBRA",
+            "HTTP-Referer": "https://example.com",
+        }
+
+    def test_extra_headers_env_var_interpolation(self, tmp_path: Path, monkeypatch):
+        """Test that env vars are interpolated in extra_headers values."""
+        monkeypatch.setenv("PROXY_TOKEN", "secret-token")
+
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[test_project]\n"
+            'name = "Test"\n'
+            'backend = "dummy"\n'
+            'extra_headers = { X-Proxy-Token = "${PROXY_TOKEN}" }\n'
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        projects = registry.load()
+
+        assert projects["test_project"].extra_headers == {
+            "X-Proxy-Token": "secret-token"
+        }
+
+    def test_extra_headers_defaults_and_override(self, tmp_path: Path):
+        """Test extra_headers merging from [defaults] with project override."""
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[defaults]\n"
+            'extra_headers = { X-Title = "default" }\n\n'
+            "[proj_a]\n"
+            'name = "Project A"\n'
+            'backend = "dummy"\n\n'
+            "[proj_b]\n"
+            'name = "Project B"\n'
+            'backend = "dummy"\n'
+            'extra_headers = { X-Title = "override" }\n'
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        projects = registry.load()
+
+        assert projects["proj_a"].extra_headers == {"X-Title": "default"}
+        assert projects["proj_b"].extra_headers == {"X-Title": "override"}
+
+    def test_extra_headers_invalid_type_raises(self, tmp_path: Path):
+        """Test that non-table extra_headers raises BackendConfigError."""
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[test_project]\n"
+            'name = "Test"\n'
+            'backend = "dummy"\n'
+            'extra_headers = "not-a-table"\n'
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        with pytest.raises(BackendConfigError, match="Invalid extra_headers"):
+            registry.load()
+
+    def test_extra_headers_non_string_value_raises(self, tmp_path: Path):
+        """Test that extra_headers with non-string values raises BackendConfigError."""
+        config_file = tmp_path / "projects.toml"
+        config_file.write_text(
+            "[test_project]\n"
+            'name = "Test"\n'
+            'backend = "dummy"\n'
+            "extra_headers = { X-Retry = 3 }\n"
+        )
+
+        registry = ProjectRegistry(str(config_file))
+        with pytest.raises(BackendConfigError, match="Invalid extra_headers"):
+            registry.load()
+
     def test_non_string_toml_values(self, tmp_path: Path):
         """Test that non-string TOML values are handled without crashing."""
         config_file = tmp_path / "projects.toml"
@@ -279,6 +383,7 @@ class TestProjectConfig:
         assert config.backend == "dummy"
         assert config.endpoint is None
         assert config.api_key is None
+        assert config.extra_headers is None
         assert config.extra == {}
 
     def test_full_config(self):
@@ -289,6 +394,7 @@ class TestProjectConfig:
             backend="nuextract",
             endpoint="http://example.com",
             api_key="secret",
+            extra_headers={"X-Title": "BIBRA"},
             extra={
                 "model": "nuextract3",
                 "thinking": True,
@@ -298,6 +404,7 @@ class TestProjectConfig:
         )
         assert config.endpoint == "http://example.com"
         assert config.api_key == "secret"
+        assert config.extra_headers == {"X-Title": "BIBRA"}
         assert config.extra["model"] == "nuextract3"
         assert config.extra["thinking"] is True
         assert config.extra["instructions"] == "Custom instructions"

--- a/tests/test_greylitlm.py
+++ b/tests/test_greylitlm.py
@@ -454,3 +454,121 @@ class TestGlobalLLMConfigEmptyStrings:
         monkeypatch.delenv("LLM_API_KEY", raising=False)
         cfg = GlobalLLMConfig(api_key="")
         assert cfg.api_key == ""
+
+
+class TestGreyLitLMBackendExtraHeaders:
+    """Tests that GreyLitLMBackend wires extra_headers into the OpenAI client."""
+
+    def test_backend_passes_extra_headers_to_client(self, monkeypatch):
+        """extra_headers should be passed to AsyncOpenAI as default_headers."""
+        from openai import AsyncOpenAI
+
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        captured = {}
+        original_init = AsyncOpenAI.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncOpenAI, "__init__", spy_init)
+        headers = {"HTTP-Referer": "https://example.com", "X-Title": "BIBRA"}
+        GreyLitLMBackend(
+            global_cfg=GlobalLLMConfig(
+                endpoint_url="http://localhost:8080/v1/",
+                api_key="test-key",
+                extra_headers=headers,
+            )
+        )
+        assert captured["default_headers"] == headers
+
+    def test_backend_passes_none_headers_to_client(self, monkeypatch):
+        """Without extra_headers, default_headers should be None."""
+        from openai import AsyncOpenAI
+
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        captured = {}
+        original_init = AsyncOpenAI.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncOpenAI, "__init__", spy_init)
+        GreyLitLMBackend(
+            global_cfg=GlobalLLMConfig(
+                endpoint_url="http://localhost:8080/v1/",
+                api_key="test-key",
+            )
+        )
+        assert captured["default_headers"] is None
+
+    def test_build_config_passes_extra_headers(self):
+        """build_config should forward project.extra_headers to GlobalLLMConfig."""
+        project = MagicMock()
+        project.endpoint = "http://localhost:8080/v1/"
+        project.api_key = "test-key"
+        project.extra_headers = {"X-Title": "BIBRA"}
+        project.extra = {}
+
+        kwargs = GreyLitLMBackend.build_config(project)
+        assert kwargs["global_cfg"].extra_headers == {"X-Title": "BIBRA"}
+
+
+class TestGlobalLLMConfigExtraHeaders:
+    """Tests for extra_headers handling in GlobalLLMConfig."""
+
+    def test_extra_headers_default_none_when_env_not_set(self, monkeypatch):
+        """extra_headers should default to None when env var is not set."""
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers is None
+
+    def test_extra_headers_explicit_dict(self, monkeypatch):
+        """Explicitly provided dict should be used as-is."""
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        headers = {"HTTP-Referer": "https://example.com", "X-Title": "BIBRA"}
+        cfg = GlobalLLMConfig(extra_headers=headers)
+        assert cfg.extra_headers == headers
+
+    def test_extra_headers_from_env_var(self, monkeypatch):
+        """extra_headers should be parsed from LLM_EXTRA_HEADERS JSON env var."""
+        monkeypatch.setenv(
+            "LLM_EXTRA_HEADERS",
+            '{"HTTP-Referer": "https://example.com", "X-Title": "BIBRA"}',
+        )
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers == {
+            "HTTP-Referer": "https://example.com",
+            "X-Title": "BIBRA",
+        }
+
+    def test_extra_headers_empty_env_var(self, monkeypatch):
+        """Empty LLM_EXTRA_HEADERS env var should result in None."""
+        monkeypatch.setenv("LLM_EXTRA_HEADERS", "  ")
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers is None
+
+    def test_extra_headers_invalid_json(self, monkeypatch):
+        """Malformed JSON in env var should be ignored (None) without raising."""
+        monkeypatch.setenv("LLM_EXTRA_HEADERS", "not-json")
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers is None
+
+    def test_extra_headers_non_object_json(self, monkeypatch):
+        """JSON that is not an object (e.g. a list) should be ignored."""
+        monkeypatch.setenv("LLM_EXTRA_HEADERS", '["X-Title", "BIBRA"]')
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers is None
+
+    def test_extra_headers_non_string_values(self, monkeypatch):
+        """Object with non-string values should be ignored."""
+        monkeypatch.setenv("LLM_EXTRA_HEADERS", '{"X-Retry": 3}')
+        cfg = GlobalLLMConfig()
+        assert cfg.extra_headers is None
+
+    def test_extra_headers_explicit_wins_over_env(self, monkeypatch):
+        """Explicitly provided dict should take precedence over env var."""
+        monkeypatch.setenv("LLM_EXTRA_HEADERS", '{"X-Title": "from-env"}')
+        cfg = GlobalLLMConfig(extra_headers={"X-Title": "explicit"})
+        assert cfg.extra_headers == {"X-Title": "explicit"}

--- a/tests/test_nuextract.py
+++ b/tests/test_nuextract.py
@@ -516,3 +516,62 @@ class TestPdfPagesToBinaryContent:
             _pdf_pages_to_binary_content("/fake/path.pdf", dpi=300)
 
             mock_page.get_pixmap.assert_called_once_with(dpi=300, alpha=False)
+
+
+class TestNuExtractBackendExtraHeaders:
+    """Tests that NuExtractBackend wires extra_headers into the OpenAI client."""
+
+    def test_backend_passes_extra_headers_to_client(self, monkeypatch):
+        """extra_headers should be passed to AsyncOpenAI as default_headers."""
+        from openai import AsyncOpenAI
+
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        captured = {}
+        original_init = AsyncOpenAI.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncOpenAI, "__init__", spy_init)
+        headers = {"X-Title": "BIBRA"}
+        NuExtractBackend(
+            global_cfg=GlobalLLMConfig(
+                endpoint_url="http://localhost:8080/v1/",
+                api_key="test-key",
+                extra_headers=headers,
+            )
+        )
+        assert captured["default_headers"] == headers
+
+    def test_backend_passes_none_headers_to_client(self, monkeypatch):
+        """Without extra_headers, default_headers should be None."""
+        from openai import AsyncOpenAI
+
+        monkeypatch.delenv("LLM_EXTRA_HEADERS", raising=False)
+        captured = {}
+        original_init = AsyncOpenAI.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncOpenAI, "__init__", spy_init)
+        NuExtractBackend(
+            global_cfg=GlobalLLMConfig(
+                endpoint_url="http://localhost:8080/v1/",
+                api_key="test-key",
+            )
+        )
+        assert captured["default_headers"] is None
+
+    def test_build_config_passes_extra_headers(self):
+        """build_config should forward project.extra_headers to GlobalLLMConfig."""
+        project = MagicMock()
+        project.endpoint = "http://localhost:8080/v1/"
+        project.api_key = "test-key"
+        project.extra_headers = {"X-Title": "BIBRA"}
+        project.extra = {}
+
+        kwargs = NuExtractBackend.build_config(project)
+        assert kwargs["global_cfg"].extra_headers == {"X-Title": "BIBRA"}


### PR DESCRIPTION
## Reasons for creating this PR
The [extra_headers](https://github.com/openai/openai-python/blob/db5c35049accb05f5fb03791ef9c12547fd309a7/src/openai/_base_client.py#L1839) can be used, for example, for authentication to the LLM endpoint when it is behind e.g. an NGINX proxy or when using some optional features of [openrouter](https://openrouter.ai/docs/api_reference/authentication).

## Link to relevant issue(s), if any

- Closes #115 

## Description of the changes in this PR
Adds optional HTTP headers to LLM requests for proxy authentication and OpenRouter attribution.

Changes:
-   Supports headers through project TOML configuration file and `LLM_EXTRA_HEADERS` env.
-   Passes headers to both OpenAI-backed clients.
-   Adds configuration and backend tests.

## Instructions how to test this PR

Use this code for a local FastAPI server:
```python
from fastapi import FastAPI, HTTPException, Request

app = FastAPI()

EXPECTED = {"x-auth": "secret" }  # header for auth

@app.post("/v1/chat/completions")
async def chat(request: Request):
    incoming = dict(request.headers)
    print("Incoming headers:", incoming)
    missing = {k: v for k, v in EXPECTED.items() if incoming.get(k) != v}
    if missing:
        # 401 makes a failure impossible to confuse with a success
        raise HTTPException(401, f"missing or wrong headers: {missing!r}")
    return {
        "id": "cmpl-1", "object": "chat.completion", "created": 0,
        "model": "test",
        "choices": [{
            "index": 0,
            "message": {"role": "assistant", "content": "{}"},
            "finish_reason": "stop",
        }],
        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
    }
```

Run it:

    uv run uvicorn header_gate:app --port 9000

And run bibra extract commands accessing the server with first correct and then incorrect key set via an env:
```
LLM_ENDPOINT_URL=http://localhost:9000/v1/ LLM_EXTRA_HEADERS="{\"x-auth\": \"secret\"}" bibra extract greylitlm ~/Documents/Annif-artikkelit/Annif_LLMs4Subjects.pdf
{
  "language": null,
  "title": null,
  "alt_title": null,
  "creator": [],
  "year": null,
  "publisher": [],
  "doi": null,
  "e_isbn": [],
  "p_isbn": [],
  "e_issn": null,
  "p_issn": null,
  "type_coar": null
}

LLM_ENDPOINT_URL=http://localhost:9000/v1/ LLM_EXTRA_HEADERS="{\"x-auth\": \"THISISWRONG\"}" bibra extract greylitlm ~/Documents/Annif-artikkelit/Annif_LLMs4Subjects.pdf
Error: Extraction failed: status_code: 401, model_name: greylitlm, body: {'detail': "missing or wrong headers: {'x-auth': 'secret'}"}
```

## Known problems or uncertainties in this PR


## Checklist


- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)


## Disclosure of AI Tool Usage
 Please indicate AI use by choosing the most suitable [TLP:AI](https://nlkw.de/en/blog/ai-tlp/) category below and removing the irrelevant categories from the list. AI:ORANGE is the minimum level for merging.

- 🟡 AI:AMBER	AI-generated, fully reviewed line by line. Author can explain every part.

Describe the AI tool(s) you used: 

<!-- Examples: -->
<!-- Zoo Code with Qwen3.6-35B-A3B -->
Zoo Code with Qwen3.6-27B
<!-- GitHub Copilot code review -->
